### PR TITLE
Sync changes from internal repo, bump version number

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2066,7 +2066,7 @@ dependencies = [
 
 [[package]]
 name = "opsqueue"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2120,7 +2120,7 @@ dependencies = [
 
 [[package]]
 name = "opsqueue_python"
-version = "0.30.4"
+version = "0.30.5"
 dependencies = [
  "anyhow",
  "chrono",

--- a/README.md
+++ b/README.md
@@ -339,6 +339,7 @@ Under the hood, the producer and the queue talk with each other using a JSON-RES
 The communication between the consumer and the queue on the other hand is done in COBR over a persistent WebSocket connection. A heartbeating protocol is used to ensure that a closed or broken connection is detected early. The goal is that the system will recognize and recover from network problems or crashed consumers within seconds.
 Similarly, as a user no detailed understanding of this should be necessary as it is abstracted away inside the client library.
 
+
 ### Consumer <-> Opsqueue Heartbeating
 
 For heartbeating between the queue and the consumer, the following approach is used:

--- a/libs/opsqueue_python/Cargo.toml
+++ b/libs/opsqueue_python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opsqueue_python"
-version = "0.30.4"
+version = "0.30.5"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/opsqueue/Cargo.toml
+++ b/opsqueue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opsqueue"
-version = "0.30.4"
+version = "0.30.5"
 edition = "2021"
 description = "lightweight batch processing queue for heavy loads"
 repository = "https://github.com/channable/opsqueue"


### PR DESCRIPTION
This PR adds the latest changes from our internal repo (a version number bump) and adds one extra blank line in the README to get it in sync with the internal version.

Merging this PR should make the `master` branches of our internal and public repo identical again.
If you agree I'll merge and tag this PR to check if the merge bot can properly tag again.