### PR TITLE
Clarify consumer log message when chunk reservation expired

### DIFF
--- a/opsqueue/src/consumer/client.rs
+++ b/opsqueue/src/consumer/client.rs
@@ -282,10 +282,9 @@ impl Client {
 
                                     },
                                     ServerToClientMessage::Async(msg) => {
-                                        // Handle a message from the server that was not associated with an earlier request
                                         match msg {
-                                            AsyncServerToClientMessage::ChunkReservationExpired(_chunk_id) => {
-                                                tracing::error!("Client could cancel execution of current work, but this is not implemented yet.");
+                                            AsyncServerToClientMessage::ChunkReservationExpired(chunk_id) => {
+                                                tracing::info!("Server indicated that we took too long with {chunk_id:?}, and now our reservation has expired.");
                                             },
                                         }
                                     }


### PR DESCRIPTION
The original message was a "todo"/future idea from when opsqueue was more actively being developed. It has a high severity (error level) and it _sounds_ actionable to users reading the logs, whereas there isn't really any way they can change the handling (because that's deep opsqueue magic). This commit changes the message to be clearer about what's going on.