### PR TITLE
Replace `ux_serde` with `ux`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2021,7 +2021,7 @@ dependencies = [
  "tracing-subscriber",
  "url",
  "uuid",
- "ux_serde",
+ "ux",
 ]
 
 [[package]]
@@ -2040,7 +2040,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
- "ux_serde",
+ "ux",
 ]
 
 [[package]]
@@ -3881,13 +3881,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ux_serde"
-version = "0.2.0"
+name = "ux"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8aaf0d6ee05126671164e6c620bfe83dc4ab13a6c8f472466dd957e309c64b9"
-dependencies = [
- "serde",
-]
+checksum = "3b59fc5417e036e53226bbebd90196825d358624fd5577432c4e486c95b1b096"
 
 [[package]]
 name = "valuable"

--- a/libs/opsqueue_python/Cargo.toml
+++ b/libs/opsqueue_python/Cargo.toml
@@ -19,7 +19,7 @@ uuid = {version = "1.11.0", features = [
         "fast-rng",          # Use a faster (but still sufficiently random) RNG
     ]}
 chrono = { version = "0.4.38"}
-ux_serde = { version = "0.2.0", features = ["std"] }
+ux = "0.1.6"
 
 # Concurrency:
 tokio = {version = "1.38", features = ["macros", "rt-multi-thread"]}

--- a/libs/opsqueue_python/src/common.rs
+++ b/libs/opsqueue_python/src/common.rs
@@ -11,7 +11,7 @@ use pyo3::prelude::*;
 
 use opsqueue::common::{chunk, submission};
 use opsqueue::consumer::strategy;
-use ux_serde::u63;
+use ux::u63;
 
 use crate::errors::{CError, CPyResult, FatalPythonException};
 

--- a/libs/opsqueue_python/src/producer.rs
+++ b/libs/opsqueue_python/src/producer.rs
@@ -20,7 +20,7 @@ use opsqueue::{
     tracing::CarrierMap,
     E,
 };
-use ux_serde::u63;
+use ux::u63;
 
 use crate::{
     async_util,

--- a/opsqueue/Cargo.toml
+++ b/opsqueue/Cargo.toml
@@ -29,6 +29,7 @@ uuid = {version = "1.11.0", features = [
         "fast-rng",          # Use a faster (but still sufficiently random) RNG
         "serde",
     ]}
+ux = "0.1.6"
 # Error handling:
 anyhow = "1.0.86"
 # Database:
@@ -64,7 +65,6 @@ moro-local = "0.4.0"
 thiserror = "1.0.65"
 either = "1.13.0"
 serde-error = "0.1.3"
-ux_serde = { version = "0.2.0", features = ["std", "serde"] }
 backon = { version = "1.3.0", features = ["tokio-sleep"] }
 rand = "0.8.5"
 rustc-hash = "2.0.0"

--- a/opsqueue/src/common/chunk.rs
+++ b/opsqueue/src/common/chunk.rs
@@ -6,20 +6,38 @@
 use chrono::{DateTime, Utc};
 
 use serde::{Deserialize, Serialize};
-use ux_serde::u63;
+use ux::u63;
 
 use super::errors::TryFromIntError;
 use super::submission::SubmissionId;
 
 /// Index of this particular chunk in a submission.
-#[derive(
-    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
-)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ChunkIndex(u63);
 
 impl std::fmt::Debug for ChunkIndex {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_tuple("ChunkIndex").field(&self.0).finish()
+    }
+}
+
+impl serde::Serialize for ChunkIndex {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        u64::from(*self).serialize(serializer)
+    }
+}
+
+impl<'a> serde::Deserialize<'a> for ChunkIndex {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'a>,
+    {
+        let value = u64::deserialize(deserializer)?;
+
+        value.try_into().map_err(serde::de::Error::custom)
     }
 }
 

--- a/opsqueue/src/common/submission.rs
+++ b/opsqueue/src/common/submission.rs
@@ -3,7 +3,7 @@ use std::fmt::Display;
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
-use ux_serde::u63;
+use ux::u63;
 
 use super::chunk::{self, Chunk, ChunkFailed, ChunkSize};
 use super::chunk::{ChunkCount, ChunkIndex};
@@ -16,10 +16,28 @@ static ID_GENERATOR: snowflaked::sync::Generator = snowflaked::sync::Generator::
 ///
 /// Submission IDs are snowflakes. These are 64-bit identifiers that includes
 /// creation time information and are sortable on that timestamp.
-#[derive(
-    Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, serde::Serialize, serde::Deserialize,
-)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SubmissionId(u63);
+
+impl serde::Serialize for SubmissionId {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        u64::from(*self).serialize(serializer)
+    }
+}
+
+impl<'a> serde::Deserialize<'a> for SubmissionId {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'a>,
+    {
+        let value = u64::deserialize(deserializer)?;
+
+        value.try_into().map_err(serde::de::Error::custom)
+    }
+}
 
 impl Default for SubmissionId {
     fn default() -> Self {

--- a/opsqueue/src/object_store/mod.rs
+++ b/opsqueue/src/object_store/mod.rs
@@ -5,7 +5,7 @@ use futures::stream::{self, TryStreamExt};
 use object_store::path::Path;
 use object_store::DynObjectStore;
 use reqwest::Url;
-use ux_serde::u63;
+use ux::u63;
 
 /// A client for interacting with an object store.
 ///


### PR DESCRIPTION
The `ux_serde` crate is rather unmaintained, and for now we can just handroll the serde impls. If that's too much boilerplate we can switch to using a macro or a newtype wrapper.