### PR TITLE
Add `.is_healthy()` method to the Opsqueue Consumer client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "opsqueue"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "opsqueue_python"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/libs/opsqueue_python/Cargo.toml
+++ b/libs/opsqueue_python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opsqueue_python"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/opsqueue/Cargo.toml
+++ b/opsqueue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opsqueue"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 description = "lightweight batch processing queue for heavy loads"
 repository = "https://github.com/channable/opsqueue"


### PR DESCRIPTION
This function can help apps using Opsqueue to decide their own healthiness level / capabilities.
