### PR TITLE
Log: Locally bound server address

### DIFF
--- a/opsqueue/app/main.rs
+++ b/opsqueue/app/main.rs
@@ -67,7 +67,6 @@ pub async fn async_main() {
             "Startup of Opsqueue ({}) complete.",
             opsqueue::version_info()
         );
-        tracing::info!("Listening on {}", &server_addr);
 
         tokio::signal::ctrl_c()
             .await

--- a/opsqueue/src/server.rs
+++ b/opsqueue/src/server.rs
@@ -44,7 +44,12 @@ pub async fn serve_producer_and_consumer(
             prometheus_config.clone(),
         );
         let listener = tokio::net::TcpListener::bind(server_addr).await?;
-
+        match listener.local_addr() {
+            Ok(addr) => tracing::info!("Server listening on {addr}"),
+            Err(err) => tracing::warn!(
+                "Could not get locally bound address of the server, tried binding on {server_addr}: {err}"
+            ),
+        }
         axum::serve(listener, router)
             .with_graceful_shutdown(cancellation_token.clone().cancelled_owned())
             .await?;


### PR DESCRIPTION
Logging the actually bound port is good for debug-ability: 

```
$ target/debug/opsqueue --port 0
Starting Opsqueue v0.32.0
Hello, hello!
2025-12-23T14:33:12.068100Z  INFO ThreadId(01) opsqueue: 24: Finished setting up tracing subscriber
2025-12-23T14:33:12.069220Z  INFO ThreadId(01) opsqueue::db: 385: Starting up using existing sqlite DB opsqueue.db
2025-12-23T14:33:12.073634Z  INFO ThreadId(01) opsqueue::db: 390: Migrating backing DB
2025-12-23T14:33:12.073792Z  INFO ThreadId(01) opsqueue::db: 397: Finished migrating backing DB
2025-12-23T14:33:12.073817Z  INFO ThreadId(01) opsqueue: 66: Startup of Opsqueue (v0.32.0) complete.
2025-12-23T14:33:12.074275Z  INFO ThreadId(01) opsqueue::server: 48: Server listening on 0.0.0.0:45953
...
```