### PR TITLE
DevEx: Rust analyzer needs `rust-src` to work

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -27,6 +27,7 @@ let
     extensions = [
       "clippy"
       "rustfmt"
+      "rust-src"
     ];
   };
 


### PR DESCRIPTION
Makes the language server work if you don't have the rust source locally via Nix
