### PR TITLE
Refactor Clippy lints in `Cargo.toml` for stricter linting rules

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,6 @@ members = [
     "libs/opsqueue_python",
 ]
 
-
 [workspace.lints.clippy]
 cargo =  { level = "warn", priority = -1 }
 cargo_common_metadata = "allow"
@@ -24,6 +23,16 @@ perf = { level = "warn", priority = -1 }
 restriction = { level = "allow", priority = -1 }
 style = { level = "warn", priority = -1 }
 suspicious = { level = "warn", priority = -1 }
+
+# Explicitly selected `restriction` lints
+mod_module_files = "warn"
+
+# Use `trace!`, `info!`, `warn!`, `error!` from `tracing` instead
+dbg_macro = "warn"
+print_stdout = "warn"
+print_stderr = "warn"
+
+rc_mutex = "warn"
 
 [profile.release]
 # Full fat LTO makes a big difference in performance, at the cost of a large


### PR DESCRIPTION
This brings the linting closer to our internally used settings.