### PR TITLE
Release version 0.32.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1972,7 +1972,7 @@ dependencies = [
 
 [[package]]
 name = "opsqueue"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2026,7 +2026,7 @@ dependencies = [
 
 [[package]]
 name = "opsqueue_python"
-version = "0.32.0"
+version = "0.32.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/libs/opsqueue_python/Cargo.toml
+++ b/libs/opsqueue_python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opsqueue_python"
-version = "0.32.0"
+version = "0.32.1"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/opsqueue/Cargo.toml
+++ b/opsqueue/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "opsqueue"
-version = "0.32.0"
+version = "0.32.1"
 edition = "2021"
 description = "lightweight batch processing queue for heavy loads"
 repository = "https://github.com/channable/opsqueue"


### PR DESCRIPTION
Changes:

- Log the locally bound server address on startup, for easier debugging, especially when the port is randomly bound (PR https://github.com/channable/opsqueue/pull/30 )
- Limit the maximum number of retries when starting Opsqueue and it failing to connect to a port. (PR https://github.com/channable/opsqueue/pull/31 )
- Ensure `rust-src` is included in the `default.nix` shell, allowing the Rust language server to work without having to pull in the rust stdlib src outside of Nix. (PR https://github.com/channable/opsqueue/pull/32)