### PR TITLE
Dependabot: Configuration for `cargo` and `rust-toolchain` updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,18 @@
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 1
+    groups:
+      cargo:
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
+  - package-ecosystem: "rust-toolchain"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/default.nix
+++ b/default.nix
@@ -23,13 +23,7 @@ let
   );
 
   # We choose a minimal Rust channel to keep the Nix closure size smaller
-  rust = pkgs.rust-bin.stable.latest.minimal.override {
-    extensions = [
-      "clippy"
-      "rustfmt"
-      "rust-src"
-    ];
-  };
+  rust = pkgs.rust-bin.fromRustupToolchainFile ./rust-toolchain.toml;
 
   defaultEnv = pkgs.buildEnv {
     name = "opsqueue-env-default";

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "5e64aecc018e6f775572609e7d7485fdba6985a7",
-        "sha256": "0yrxlrdvmk9y656ablpvqnajjax88dqyb9yx9ziziw8vddb0h0x7",
+        "rev": "6d14586a5917a1ec7f045ac97e6d00c68ea5d9f3",
+        "sha256": "0kzg34bv6ap1jgq8x2bawn7rv3pkhd53z8zdvpykyvqqkxpw0dsf",
         "type": "tarball",
-        "url": "https://github.com/oxalica/rust-overlay/archive/5e64aecc018e6f775572609e7d7485fdba6985a7.tar.gz",
+        "url": "https://github.com/oxalica/rust-overlay/archive/6d14586a5917a1ec7f045ac97e6d00c68ea5d9f3.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     }
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,4 @@
+[toolchain]
+channel = "1.92.0"
+components = ["clippy", "rustfmt", "rust-analyzer", "rust-src"]
+profile = "minimal"


### PR DESCRIPTION
There was a request to keep our dependencies up-to-date in our internal chat, making Dependabot perform these updates regularly.

Fixes https://github.com/channable/opsqueue/issues/37