### PR TITLE
In tests on CI, store the test DBs in memory to fix self-hosted Semaphore runners sometimes hanging

### DIFF
--- a/libs/opsqueue_python/tests/conftest.py
+++ b/libs/opsqueue_python/tests/conftest.py
@@ -4,7 +4,6 @@ from contextlib import contextmanager, ExitStack
 from typing import Generator, Callable, Any, Iterable
 import multiprocessing
 import subprocess
-import uuid
 import os
 import pytest
 from dataclasses import dataclass
@@ -59,7 +58,14 @@ def opsqueue_service(
     if port is None:
         port = random_free_port()
 
-    temp_dbname = f"/tmp/opsqueue_tests-{uuid.uuid4()}.db"
+    # This will create a SQLite database in memory.
+    # We need the `cache=shared` to allow sharing this DB between all threads within the same OS process.
+    temp_dbname = "file::memory:?cache=shared"
+
+    # Switch this for the following if debugging a particular test locally.
+    # This is not the default because specifically Semaphore backed with Butterfs
+    # will from time to time hang for **many minutes** on initializing SQLite for some reason.
+    # temp_dbname = f"/tmp/opsqueue_tests-{uuid.uuid4()}.db"
 
     command = [
         str(opsqueue_bin_location()),


### PR DESCRIPTION
This is with high certainty the cause of the Semaphore hangs we have seen in the past, which took @rlycx, @ReinierMaas, @SanderHageman and myself a huuuge amount of work to debug: There is an interaction between writing a file to `/tmp/` (which, to my surprise, is _not_ a `tmpfs` in Semaphore) on Butterfs when using many small fsyncs (which as it turns out, Sqlite does when initializing a new DB, esp in WAL mode), and then doing this for dozens of tests in parallel.

This will cause one of these `fsync`s to hang for many minutes on end, with the OS busy doing some kind of disk vacuuming.

This PR changes Opsqueue to run in a 100% in-memory mode in the integration test suite instead.