### PR TITLE
Add stategic metadata to insert_submission, SubmissionCompleted and SubmissionFailed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2085,7 +2085,7 @@ dependencies = [
 
 [[package]]
 name = "opsqueue"
-version = "0.33.2"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2139,7 +2139,7 @@ dependencies = [
 
 [[package]]
 name = "opsqueue_python"
-version = "0.33.2"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.33.2"
+version = "0.34.0"
 
 
 [workspace.lints.clippy]

--- a/libs/opsqueue_python/python/opsqueue/producer.py
+++ b/libs/opsqueue_python/python/opsqueue/producer.py
@@ -18,6 +18,7 @@ from opsqueue.exceptions import SubmissionFailedError
 from .opsqueue_internal import (  # type: ignore[import-not-found]
     SubmissionId,
     SubmissionStatus,
+    SubmissionCompleted,
     SubmissionFailed,
     ChunkFailed,
 )
@@ -26,6 +27,7 @@ __all__ = [
     "ProducerClient",
     "SubmissionId",
     "SubmissionStatus",
+    "SubmissionCompleted",
     "SubmissionFailedError",
     "SubmissionFailed",
     "ChunkFailed",
@@ -83,7 +85,7 @@ class ProducerClient:
         chunk_size: int,
         serialization_format: SerializationFormat = DEFAULT_SERIALIZATION_FORMAT,
         metadata: None | bytes = None,
-        strategic_metadata: None | dict[str, str | int] = None,
+        strategic_metadata: None | dict[str, int] = None,
     ) -> Iterator[Any]:
         """
         Inserts a submission into the queue, and blocks until it is completed.
@@ -114,7 +116,7 @@ class ProducerClient:
         chunk_size: int,
         serialization_format: SerializationFormat = DEFAULT_SERIALIZATION_FORMAT,
         metadata: None | bytes = None,
-        strategic_metadata: None | dict[str, str | int] = None,
+        strategic_metadata: None | dict[str, int] = None,
     ) -> AsyncIterator[Any]:
         tracer = trace.get_tracer("opsqueue.producer")
         with tracer.start_as_current_span("run_submission"):
@@ -133,6 +135,7 @@ class ProducerClient:
         chunk_size: int,
         serialization_format: SerializationFormat = DEFAULT_SERIALIZATION_FORMAT,
         metadata: None | bytes = None,
+        strategic_metadata: None | dict[str, int] = None,
     ) -> SubmissionId:
         """
         Inserts a submission into the queue,
@@ -147,6 +150,7 @@ class ProducerClient:
         return self.insert_submission_chunks(
             _chunk_iterator(ops, chunk_size, serialization_format),
             metadata=metadata,
+            strategic_metadata=strategic_metadata,
             chunk_size=chunk_size,
         )
 
@@ -195,7 +199,7 @@ class ProducerClient:
         chunk_contents: Iterable[bytes],
         *,
         metadata: None | bytes = None,
-        strategic_metadata: None | dict[str, str | int] = None,
+        strategic_metadata: None | dict[str, int] = None,
         chunk_size: None | int = None,
     ) -> Iterator[bytes]:
         """
@@ -222,7 +226,7 @@ class ProducerClient:
         chunk_contents: Iterable[bytes],
         *,
         metadata: None | bytes = None,
-        strategic_metadata: None | dict[str, str | int] = None,
+        strategic_metadata: None | dict[str, int] = None,
         chunk_size: None | int = None,
     ) -> AsyncIterator[bytes]:
         # NOTE: the insertion is not currently async.
@@ -243,7 +247,7 @@ class ProducerClient:
         chunk_contents: Iterable[bytes],
         *,
         metadata: None | bytes = None,
-        strategic_metadata: None | dict[str, str | int] = None,
+        strategic_metadata: None | dict[str, int] = None,
         chunk_size: None | int = None,
     ) -> SubmissionId:
         """

--- a/libs/opsqueue_python/src/common.rs
+++ b/libs/opsqueue_python/src/common.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 use chrono::{DateTime, Utc};
 use opsqueue::common::errors::TryFromIntError;
 use opsqueue::common::submission::Metadata;
+use opsqueue::common::StrategicMetadataMap;
 use opsqueue::object_store::{ChunkRetrievalError, ChunkType, ObjectStoreClient};
 use opsqueue::tracing::CarrierMap;
 use pyo3::prelude::*;
@@ -299,6 +300,7 @@ impl From<opsqueue::common::submission::SubmissionCompleted> for SubmissionCompl
             completed_at: value.completed_at,
             chunks_total: value.chunks_total.into(),
             metadata: value.metadata,
+            strategic_metadata: value.strategic_metadata,
         }
     }
 }
@@ -310,6 +312,7 @@ impl From<opsqueue::common::submission::SubmissionFailed> for SubmissionFailed {
             failed_at: value.failed_at,
             chunks_total: value.chunks_total.into(),
             metadata: value.metadata,
+            strategic_metadata: value.strategic_metadata,
             failed_chunk_id: value.failed_chunk_id.into(),
         }
     }
@@ -393,11 +396,12 @@ impl SubmissionStatus {
 impl SubmissionCompleted {
     fn __repr__(&self) -> String {
         format!(
-            "SubmissionCompleted(id={0}, chunks_total={1}, completed_at={2}, metadata={3:?})",
+            "SubmissionCompleted(id={0}, chunks_total={1}, completed_at={2}, metadata={3:?}, strategic_metadata={4:?})",
             self.id.__repr__(),
             self.chunks_total,
             self.completed_at,
-            self.metadata
+            self.metadata,
+            self.strategic_metadata
         )
     }
 }
@@ -405,8 +409,8 @@ impl SubmissionCompleted {
 #[pymethods]
 impl SubmissionFailed {
     fn __repr__(&self) -> String {
-        format!("SubmissionFailed(id={0}, chunks_total={1}, failed_at={2}, failed_chunk_id={3}, metadata={4:?})",
-        self.id.__repr__(), self.chunks_total, self.failed_at, self.failed_chunk_id, self.metadata)
+        format!("SubmissionFailed(id={0}, chunks_total={1}, failed_at={2}, failed_chunk_id={3}, metadata={4:?}, strategic_metadata={5:?})",
+        self.id.__repr__(), self.chunks_total, self.failed_at, self.failed_chunk_id, self.metadata, self.strategic_metadata)
     }
 }
 
@@ -416,6 +420,7 @@ pub struct SubmissionCompleted {
     pub id: SubmissionId,
     pub chunks_total: u64,
     pub metadata: Option<submission::Metadata>,
+    pub strategic_metadata: Option<StrategicMetadataMap>,
     pub completed_at: DateTime<Utc>,
 }
 
@@ -425,6 +430,7 @@ pub struct SubmissionFailed {
     pub id: SubmissionId,
     pub chunks_total: u64,
     pub metadata: Option<submission::Metadata>,
+    pub strategic_metadata: Option<StrategicMetadataMap>,
     pub failed_at: DateTime<Utc>,
     pub failed_chunk_id: u64,
 }

--- a/libs/opsqueue_python/src/lib.rs
+++ b/libs/opsqueue_python/src/lib.rs
@@ -21,6 +21,7 @@ fn opsqueue_internal(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<common::ChunkFailed>()?;
     m.add_class::<common::SubmissionStatus>()?;
     m.add_class::<common::Submission>()?;
+    m.add_class::<common::SubmissionCompleted>()?;
     m.add_class::<common::SubmissionFailed>()?;
     m.add_class::<producer::PyChunksIter>()?;
     m.add_class::<consumer::ConsumerClient>()?;


### PR DESCRIPTION
Add stategic metadata as a parameter to `insert_submission` (which just passes it to `insert_submission_chunks`), and make the strategic metadata available in the submission results: `SubmissionCompleted` and `SubmissionFailed`.