### PR TITLE
Makes passing the 'rustToolchain' optional when using pkgs.callPackage to build opsqueue.nix or opsqueue_python.nix

### DIFF
--- a/libs/opsqueue_python/opsqueue_python.nix
+++ b/libs/opsqueue_python/opsqueue_python.nix
@@ -3,8 +3,14 @@
   pkgs,
   lib,
 
-  # Rust version. (Override this with an overlay if you like)
-  rustToolchain,
+  # Downstream users can override which Rust version is used.
+  # But this is opt-in. By default we'll use the same version
+  # that we use in this repo for development.
+  rustToolchain ? (
+    (lib.fix (final: pkgs // (import (import ../../nix/sources.nix).rust-overlay) final pkgs))
+    .rust-bin.fromRustupToolchainFile
+      ../../rust-toolchain.toml
+  ),
 
   # Native build dependencies:
   maturin,

--- a/opsqueue/opsqueue.nix
+++ b/opsqueue/opsqueue.nix
@@ -1,8 +1,16 @@
 {
   pkgs,
   lib,
-  rustToolchain,
   git,
+
+  # Downstream users can override which Rust version is used.
+  # But this is opt-in. By default we'll use the same version
+  # that we use in this repo for development.
+  rustToolchain ? (
+    (lib.fix (final: pkgs // (import (import ./nix/sources.nix).rust-overlay) final pkgs))
+    .rust-bin.fromRustupToolchainFile
+      ./rust-toolchain.toml
+  ),
 }:
 let
   sources = import ../nix/sources.nix;


### PR DESCRIPTION
Makes passing the 'rustToolchain' optional when using pkgs.callPackage to build opsqueue.nix or opsqueue_python.nix.

They can still be overridden by specifying a different Rust version in the overlay. But if kept at its default, will use the version from the `rust-toolchain.toml` in the opsqueue repo itself.

By making this optional, users of the library do not need to care about which Rust version they are using. Except that if they _are_ using a particular version for other parts of their software, they can ensure they use the same (to prevent building deps twice, for example).