### PR TITLE
Include sqlite3 in the Nix devshell, for easier debugging/introspection

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -48,6 +48,9 @@ let
       pkgs.cargo-edit
       pkgs.cargo-nextest
       pkgs.maturin
+
+      # sqlite3 binary, for easy debugging/introspection
+      pkgs.sqlite
     ];
   };
   environments = {


### PR DESCRIPTION
CC @bertptrs

No new Rust version release or OpsBotPrime tag as this is only a change in the direnv environment.

@OpsBotPrime merge