### PR TITLE
Allow overriding Python version when calling the opsqueue_python Nix package

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,16 @@ Opsqueue's client libraries and binary itself are also available through `niv`.
 2. Package the now available `opsqueue` library as part of your overlay, using e.g.
 
 ```nix
-opsqueue = self.callPackage (sources.opsqueue + "/libs/opsqueue_python/opsqueue_python.nix") { };
+opsqueue_client = self.callPackage (sources.opsqueue + "/libs/opsqueue_python/opsqueue_python.nix") { };
+```
+
+- If you want to override which Rust version is used, you can set the `rustToolchain` either in an overlay or by passing it as parameter directly to `callPackage`.
+- If you want to override which Python version is used for the Python client, you can set `python` either in an overlay or by passing it as parameter directly to `callPackage`.
+
+For example:
+
+```nix
+opsqueue_client = self.callPackage (sources.opsqueue + "/libs/opsqueue_python/opsqueue_python.nix") { python = mySpecialPython; };
 ```
 
 ## For devs modifying Opsqueue: Building, running, testing

--- a/libs/opsqueue_python/opsqueue_python.nix
+++ b/libs/opsqueue_python/opsqueue_python.nix
@@ -23,9 +23,12 @@
   opentelemetry-api,
   opentelemetry-exporter-otlp,
   opentelemetry-sdk,
+
+  # Downstream users can override which precise Python version is used.
+  # This is opt-in; by default we will use whatever 'python3' is in scope.
+  python ? (pkgs.python3),
 }:
 let
-  python = pkgs.python3;
   sources = import ../../nix/sources.nix;
   crane = import sources.crane { pkgs = pkgs; };
   craneLib = crane.overrideToolchain (pkgs: rustToolchain);


### PR DESCRIPTION
Without this, if e.g. a user of the Nix Python package builds their own python that is separate from `pkgs.python3` (e.g. rather than overriding that one in an overlay, they create a separate one), it is likely that the resulting wheel / compiled FFI module is not placed in the right location, which makes the build fail (at the 'can I find all the imports' step).

This PR fixes that, by adding `python = ...`  to the parameters of `opsqueue_python.nix` meaning that a user can do `callPackage "......./opsqueue_python.nix" { python = myOtherPython; };` and be merry.