### PR TITLE
Upgrade PyO3 to version 0.25.x to support Python 3.14

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2377,11 +2377,10 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.23.5"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7778bffd85cf38175ac1f545509665d0b9b92a198ca7941f131f85f7a4f9a872"
+checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
 dependencies = [
- "cfg-if",
  "chrono",
  "indoc",
  "libc",
@@ -2396,9 +2395,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.23.0"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "977dc837525cfd22919ba6a831413854beb7c99a256c03bf8624ad707e45810e"
+checksum = "d73cc6b1b7d8b3cef02101d37390dbdfe7e450dfea14921cae80a9534ba59ef2"
 dependencies = [
  "async-channel",
  "futures",
@@ -2410,9 +2409,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.23.5"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94f6cbe86ef3bf18998d9df6e0f3fc1050a8c5efa409bf712e661a4366e010fb"
+checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
 dependencies = [
  "once_cell",
  "target-lexicon",
@@ -2420,9 +2419,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.23.5"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f1b4c431c0bb1c8fb0a338709859eed0d030ff6daa34368d3b152a63dfdd8d"
+checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2441,9 +2440,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.23.5"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbc2201328f63c4710f68abdf653c89d8dbc2858b88c5d88b0ff38a75288a9da"
+checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2453,9 +2452,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.23.5"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fca6726ad0f3da9c9de093d6f116a93c1a38e417ed73bf138472cf4064f72028"
+checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -3530,9 +3529,9 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.16"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"

--- a/README.md
+++ b/README.md
@@ -119,7 +119,16 @@ Opsqueue's client libraries and binary itself are also available through `niv`.
 2. Package the now available `opsqueue` library as part of your overlay, using e.g.
 
 ```nix
-opsqueue = self.callPackage (sources.opsqueue + "/libs/opsqueue_python/opsqueue_python.nix") { };
+opsqueue_client = self.callPackage (sources.opsqueue + "/libs/opsqueue_python/opsqueue_python.nix") { };
+```
+
+- If you want to override which Rust version is used, you can set the `rustToolchain` either in an overlay or by passing it as parameter directly to `callPackage`.
+- If you want to override which Python version is used for the Python client, you can set `python3` either in an overlay or by passing it as parameter directly to `callPackage`.
+
+For example:
+
+```nix
+opsqueue_client = self.callPackage (sources.opsqueue + "/libs/opsqueue_python/opsqueue_python.nix") { python3 = mySpecialPython; };
 ```
 
 ## For devs modifying Opsqueue: Building, running, testing

--- a/README.md
+++ b/README.md
@@ -123,12 +123,12 @@ opsqueue_client = self.callPackage (sources.opsqueue + "/libs/opsqueue_python/op
 ```
 
 - If you want to override which Rust version is used, you can set the `rustToolchain` either in an overlay or by passing it as parameter directly to `callPackage`.
-- If you want to override which Python version is used for the Python client, you can set `python3` either in an overlay or by passing it as parameter directly to `callPackage`.
+- If you want to override which Python version is used for the Python client, you can set `python` either in an overlay or by passing it as parameter directly to `callPackage`.
 
 For example:
 
 ```nix
-opsqueue_client = self.callPackage (sources.opsqueue + "/libs/opsqueue_python/opsqueue_python.nix") { python3 = mySpecialPython; };
+opsqueue_client = self.callPackage (sources.opsqueue + "/libs/opsqueue_python/opsqueue_python.nix") { python = mySpecialPython; };
 ```
 
 ## For devs modifying Opsqueue: Building, running, testing

--- a/libs/opsqueue_python/Cargo.toml
+++ b/libs/opsqueue_python/Cargo.toml
@@ -30,10 +30,10 @@ anyhow = "1.0.86"
 thiserror = "1.0.65"
 
 # Python FFI:
-pyo3 = { version = "0.23.4", features = ["chrono"] }
-pyo3-async-runtimes = { version = "0.23.0", features = ["tokio-runtime", "unstable-streams"] }
+pyo3 = { version = "0.25", features = ["chrono"] }
+pyo3-async-runtimes = { version = "0.25", features = ["tokio-runtime", "unstable-streams"] }
 once_cell = "1.21.3" # Only currently used for `unsync::OnceCell` as part of PyO3 async helpers.
 
 # Logging/tracing:
-pyo3-log = "0.12.1"
+pyo3-log = "0.12"
 tracing = { version = "0.1.41", features = ["log"] }

--- a/libs/opsqueue_python/opsqueue_python.nix
+++ b/libs/opsqueue_python/opsqueue_python.nix
@@ -78,7 +78,7 @@ let
     )).overrideAttrs
       (old: {
         nativeBuildInputs = old.nativeBuildInputs ++ [ maturin ];
-        env.PYO3_PYTHON = python.interpreter;
+        env.PYO3_PYTHON = python3.interpreter;
 
         # We intentionally _override_ rather than extend the buildPhase
         # as Maturin itself calls `cargo build`, no need to call it twice.

--- a/libs/opsqueue_python/opsqueue_python.nix
+++ b/libs/opsqueue_python/opsqueue_python.nix
@@ -26,7 +26,7 @@
 
   # Downstream users can override which precise Python version is used.
   # This is opt-in; by default we will use whatever 'python3' is in scope.
-  python3 ? (pkgs.python3),
+  python ? (pkgs.python3),
 }:
 let
   sources = import ../../nix/sources.nix;
@@ -59,7 +59,7 @@ let
     inherit version pname;
     src = depsSrc;
     strictDeps = true;
-    nativeBuildInputs = [ python3 ];
+    nativeBuildInputs = [ python ];
     cargoExtraArgs = "--package opsqueue_python";
     doCheck = false;
   };
@@ -78,7 +78,7 @@ let
     )).overrideAttrs
       (old: {
         nativeBuildInputs = old.nativeBuildInputs ++ [ maturin ];
-        env.PYO3_PYTHON = python3.interpreter;
+        env.PYO3_PYTHON = python.interpreter;
 
         # We intentionally _override_ rather than extend the buildPhase
         # as Maturin itself calls `cargo build`, no need to call it twice.

--- a/libs/opsqueue_python/opsqueue_python.nix
+++ b/libs/opsqueue_python/opsqueue_python.nix
@@ -23,9 +23,9 @@
   opentelemetry-api,
   opentelemetry-exporter-otlp,
   opentelemetry-sdk,
+  python ? (pkgs.python3),
 }:
 let
-  python = pkgs.python3;
   sources = import ../../nix/sources.nix;
   crane = import sources.crane { pkgs = pkgs; };
   craneLib = crane.overrideToolchain (pkgs: rustToolchain);

--- a/libs/opsqueue_python/opsqueue_python.nix
+++ b/libs/opsqueue_python/opsqueue_python.nix
@@ -23,7 +23,10 @@
   opentelemetry-api,
   opentelemetry-exporter-otlp,
   opentelemetry-sdk,
-  python ? (pkgs.python3),
+
+  # Downstream users can override which precise Python version is used.
+  # This is opt-in; by default we will use whatever 'python3' is in scope.
+  python3 ? (pkgs.python3),
 }:
 let
   sources = import ../../nix/sources.nix;
@@ -56,7 +59,7 @@ let
     inherit version pname;
     src = depsSrc;
     strictDeps = true;
-    nativeBuildInputs = [ python ];
+    nativeBuildInputs = [ python3 ];
     cargoExtraArgs = "--package opsqueue_python";
     doCheck = false;
   };


### PR DESCRIPTION
The newest version of PyO3 is 0.28.x at the time of writing, but in
0.26 a bunch of big API changes have been introduced which may prove to be
somewhat time-consuming to resolve.

Upgrading to 0.25 first is a good first step which will already unblock people using Python 3.14