### PR TITLE
Include a `py.typed` marker file with the Python client

### DIFF
--- a/libs/opsqueue_python/opsqueue_python.nix
+++ b/libs/opsqueue_python/opsqueue_python.nix
@@ -44,7 +44,7 @@ let
   };
 
   # Full set of files to build the Python wheel on top
-  pythonFileFilter = path: _type: builtins.match "^.*\.(py|md)$" path != null;
+  pythonFileFilter = path: _type: builtins.match "^.*(py.typed|\.(py|md))$" path != null;
   wheelFileFilter = path: type: (pythonFileFilter path type) || (rustCrateFileFilter path type);
   wheelSrc = lib.cleanSourceWith {
     src = ../../.;

--- a/libs/opsqueue_python/pyproject.toml
+++ b/libs/opsqueue_python/pyproject.toml
@@ -35,6 +35,7 @@ Issues="https://github.com/channable/opsqueue/issues"
 features = ["pyo3/extension-module"]
 python-source = "python"
 module-name = "opsqueue.opsqueue_internal"
+include = ["**/py.typed"]
 
 # We specify test-dependencies here (and have them loaded through `.setup_local_venv.sh`)
 # because otherwise `pytest` won't be able to see the locally build python package!


### PR DESCRIPTION
Closes https://github.com/channable/opsqueue/issues/8. I've checked that the `py.typed` file is included when building via Nix, and then using `reveal_type` on `ProducerClient.get_submission_status` changes mypy reporting
```
note: Revealed type is "Any"
```
into
```
note: Revealed type is "def (submission_id: Any) -> Any | None"
```

So this doesn't entirely make types available, due to https://github.com/PyO3/pyo3/issues/5137, but it improves the situation.