### PR TITLE
Bump pyo3: 0.25.1 -> 0.28.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2618,9 +2618,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8970a78afe0628a3e3430376fc5fd76b6b45c4d43360ffd6cdd40bdde72b682a"
+checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
 dependencies = [
  "chrono",
  "indoc",
@@ -2636,9 +2636,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.25.0"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d73cc6b1b7d8b3cef02101d37390dbdfe7e450dfea14921cae80a9534ba59ef2"
+checksum = "e6ee6d4cb3e8d5b925f5cdb38da183e0ff18122eb2048d4041c9e7034d026e23"
 dependencies = [
  "async-channel",
  "futures",
@@ -2650,19 +2650,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "458eb0c55e7ece017adeba38f2248ff3ac615e53660d7c71a238d7d2a01c7598"
+checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7114fe5457c61b276ab77c5055f206295b812608083644a5c5b2640c3102565c"
+checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2670,9 +2669,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-log"
-version = "0.12.4"
+version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45192e5e4a4d2505587e27806c7b710c231c40c56f3bfc19535d0bb25df52264"
+checksum = "26c2ec80932c5c3b2d4fbc578c9b56b2d4502098587edb8bef5b6bfcad43682e"
 dependencies = [
  "arc-swap",
  "log",
@@ -2681,9 +2680,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8725c0a622b374d6cb051d11a0983786448f7785336139c3c94f5aa6bef7e50"
+checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2693,9 +2692,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.25.1"
+version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4109984c22491085343c05b0dbc54ddc405c3cf7b4374fc533f5c3313a572ccc"
+checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2618,9 +2618,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ba0117f4212101ee6544044dae45abe1083d30ce7b29c4b5cbdfa2354e07383"
+checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
 dependencies = [
  "chrono",
  "indoc",
@@ -2636,9 +2636,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.26.0"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6ee6d4cb3e8d5b925f5cdb38da183e0ff18122eb2048d4041c9e7034d026e23"
+checksum = "57ddb5b570751e93cc6777e81fee8087e59cd53b5043292f2a6d59d5bd80fdfd"
 dependencies = [
  "async-channel",
  "futures",
@@ -2650,18 +2650,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fc6ddaf24947d12a9aa31ac65431fb1b851b8f4365426e182901eabfb87df5f"
+checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "025474d3928738efb38ac36d4744a74a400c901c7596199e20e45d98eb194105"
+checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2680,9 +2680,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e64eb489f22fe1c95911b77c44cc41e7c19f3082fc81cce90f657cdc42ffded"
+checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2692,9 +2692,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.26.0"
+version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "100246c0ecf400b475341b8455a9213344569af29a3c841d29270e53102e0fcf"
+checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
 dependencies = [
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1511,15 +1511,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "2.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79cf5c93f93228cf8efb3ba362535fb11199ac548a09ce117c9b1adc3030d706"
-dependencies = [
- "rustversion",
-]
-
-[[package]]
 name = "insta"
 version = "1.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1790,15 +1781,6 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
-
-[[package]]
-name = "memoffset"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
-dependencies = [
- "autocfg",
-]
 
 [[package]]
 name = "metrics"
@@ -2618,30 +2600,28 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.27.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
  "chrono",
- "indoc",
  "libc",
- "memoffset",
  "once_cell",
  "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-async-runtimes"
-version = "0.27.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57ddb5b570751e93cc6777e81fee8087e59cd53b5043292f2a6d59d5bd80fdfd"
+checksum = "9e7364a95bf00e8377bbf9b0f09d7ff9715a29d8fcf93b47d1a967363b973178"
 dependencies = [
  "async-channel",
- "futures",
+ "futures-channel",
+ "futures-util",
  "once_cell",
  "pin-project-lite",
  "pyo3",
@@ -2650,18 +2630,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.27.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b455933107de8642b4487ed26d912c2d899dec6114884214a0b3bb3be9261ea6"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.27.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2680,9 +2660,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.27.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a5b10c9bf9888125d917fb4d2ca2d25c8df94c7ab5a52e13313a07e050a3b02"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2692,9 +2672,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.27.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b51720d314836e53327f5871d4c0cfb4fb37cc2c4a11cc71907a86342c40f9"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -4300,12 +4280,6 @@ name = "unicode_categories"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39ec24b3121d976906ece63c9daad25b85969647682eee313cb5779fdd69e14e"
-
-[[package]]
-name = "unindent"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
 
 [[package]]
 name = "untrusted"

--- a/libs/opsqueue_python/Cargo.toml
+++ b/libs/opsqueue_python/Cargo.toml
@@ -30,10 +30,10 @@ anyhow = "1.0.102"
 thiserror = "2.0.18"
 
 # Python FFI:
-pyo3 = { version = "0.25", features = ["chrono"] }
-pyo3-async-runtimes = { version = "0.25", features = ["tokio-runtime", "unstable-streams"] }
+pyo3 = { version = "0.26", features = ["chrono"] }
+pyo3-async-runtimes = { version = "0.26", features = ["tokio-runtime", "unstable-streams"] }
 once_cell = "1.21.4" # Only currently used for `unsync::OnceCell` as part of PyO3 async helpers.
 
 # Logging/tracing:
-pyo3-log = "0.12.1"
+pyo3-log = "0.13.3"
 tracing = { version = "0.1.41", features = ["log"] }

--- a/libs/opsqueue_python/Cargo.toml
+++ b/libs/opsqueue_python/Cargo.toml
@@ -30,8 +30,8 @@ anyhow = "1.0.102"
 thiserror = "2.0.18"
 
 # Python FFI:
-pyo3 = { version = "0.27.2", features = ["chrono"] }
-pyo3-async-runtimes = { version = "0.27.0", features = ["tokio-runtime", "unstable-streams"] }
+pyo3 = { version = "0.28.3", features = ["chrono"] }
+pyo3-async-runtimes = { version = "0.28.0", features = ["tokio-runtime", "unstable-streams"] }
 once_cell = "1.21.4" # Only currently used for `unsync::OnceCell` as part of PyO3 async helpers.
 
 # Logging/tracing:

--- a/libs/opsqueue_python/Cargo.toml
+++ b/libs/opsqueue_python/Cargo.toml
@@ -30,8 +30,8 @@ anyhow = "1.0.102"
 thiserror = "2.0.18"
 
 # Python FFI:
-pyo3 = { version = "0.26", features = ["chrono"] }
-pyo3-async-runtimes = { version = "0.26", features = ["tokio-runtime", "unstable-streams"] }
+pyo3 = { version = "0.27.2", features = ["chrono"] }
+pyo3-async-runtimes = { version = "0.27.0", features = ["tokio-runtime", "unstable-streams"] }
 once_cell = "1.21.4" # Only currently used for `unsync::OnceCell` as part of PyO3 async helpers.
 
 # Logging/tracing:

--- a/libs/opsqueue_python/src/async_util.rs
+++ b/libs/opsqueue_python/src/async_util.rs
@@ -31,9 +31,7 @@ where
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let waker = cx.waker();
-        Python::attach(|py| {
-            py.detach(|| pin!(&mut self.0).poll(&mut Context::from_waker(waker)))
-        })
+        Python::attach(|py| py.detach(|| pin!(&mut self.0).poll(&mut Context::from_waker(waker))))
     }
 }
 
@@ -96,7 +94,7 @@ impl pyo3_async_runtimes::generic::ContextExt for TokioRuntimeThatIsInScope {
 
     fn get_task_locals() -> Option<TaskLocals> {
         TASK_LOCALS
-            .try_with(|c| { c.get().cloned() })
+            .try_with(|c| c.get().cloned())
             .unwrap_or_default()
     }
 }

--- a/libs/opsqueue_python/src/async_util.rs
+++ b/libs/opsqueue_python/src/async_util.rs
@@ -41,7 +41,7 @@ where
 pub fn future_into_py<T, F>(py: Python<'_>, fut: F) -> PyResult<Bound<'_, PyAny>>
 where
     F: Future<Output = PyResult<T>> + Send + 'static,
-    T: for<'py> IntoPyObject<'py>,
+    T: for<'py> IntoPyObject<'py> + Send + 'static,
 {
     pyo3_async_runtimes::generic::future_into_py::<TokioRuntimeThatIsInScope, F, T>(py, fut)
 }
@@ -71,6 +71,13 @@ impl pyo3_async_runtimes::generic::Runtime for TokioRuntimeThatIsInScope {
             fut.await;
         })
     }
+
+    fn spawn_blocking<F>(f: F) -> Self::JoinHandle
+    where
+        F: FnOnce() + Send + 'static,
+    {
+        tokio::task::spawn_blocking(f)
+    }
 }
 
 impl pyo3_async_runtimes::generic::ContextExt for TokioRuntimeThatIsInScope {
@@ -89,10 +96,7 @@ impl pyo3_async_runtimes::generic::ContextExt for TokioRuntimeThatIsInScope {
 
     fn get_task_locals() -> Option<TaskLocals> {
         TASK_LOCALS
-            .try_with(|c| {
-                c.get()
-                    .map(|locals| Python::attach(|py| locals.clone_ref(py)))
-            })
+            .try_with(|c| { c.get().cloned() })
             .unwrap_or_default()
     }
 }

--- a/libs/opsqueue_python/src/async_util.rs
+++ b/libs/opsqueue_python/src/async_util.rs
@@ -8,14 +8,14 @@ use std::{
     task::{Context, Poll},
 };
 
-/// Unlock the GIL across `.await` points
+/// Unlock the GIL across `.await` points in GIL enabled builds.
 ///
-/// Essentially `py.allow_threads` but for async code.
+/// Essentially `py.detach` but for async code.
 ///
 /// Based on https://pyo3.rs/v0.25.1/async-await.html#release-the-gil-across-await
 pub struct AsyncAllowThreads<F>(F);
 
-pub fn async_allow_threads<F>(fut: F) -> AsyncAllowThreads<F>
+pub fn async_detach<F>(fut: F) -> AsyncAllowThreads<F>
 where
     F: Future,
 {
@@ -31,8 +31,8 @@ where
 
     fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let waker = cx.waker();
-        Python::with_gil(|py| {
-            py.allow_threads(|| pin!(&mut self.0).poll(&mut Context::from_waker(waker)))
+        Python::attach(|py| {
+            py.detach(|| pin!(&mut self.0).poll(&mut Context::from_waker(waker)))
         })
     }
 }
@@ -91,7 +91,7 @@ impl pyo3_async_runtimes::generic::ContextExt for TokioRuntimeThatIsInScope {
         TASK_LOCALS
             .try_with(|c| {
                 c.get()
-                    .map(|locals| Python::with_gil(|py| locals.clone_ref(py)))
+                    .map(|locals| Python::attach(|py| locals.clone_ref(py)))
             })
             .unwrap_or_default()
     }

--- a/libs/opsqueue_python/src/common.rs
+++ b/libs/opsqueue_python/src/common.rs
@@ -24,7 +24,7 @@ pub const SIGNAL_CHECK_INTERVAL: Duration = Duration::from_millis(100);
 #[cfg(not(debug_assertions))]
 pub const SIGNAL_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 
-#[pyclass(frozen, get_all, eq, ord, hash, module = "opsqueue")]
+#[pyclass(from_py_object, frozen, get_all, eq, ord, hash, module = "opsqueue")]
 #[derive(Debug, Copy, Clone, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct SubmissionId {
     pub id: u64,
@@ -59,7 +59,7 @@ impl From<submission::SubmissionId> for SubmissionId {
     }
 }
 
-#[pyclass(frozen, get_all, eq, ord, hash, module = "opsqueue")]
+#[pyclass(from_py_object, frozen, get_all, eq, ord, hash, module = "opsqueue")]
 #[derive(Debug, Clone, Copy, Hash, PartialEq, Eq, PartialOrd, Ord)]
 pub struct ChunkIndex {
     pub id: u64,
@@ -205,7 +205,7 @@ impl Eq for Strategy {}
 
 /// Wrapper for the internal Opsqueue Chunk datatype
 /// Note that it also includes some fields originating from the Submission
-#[pyclass(frozen, get_all, module = "opsqueue")]
+#[pyclass(from_py_object, frozen, get_all, module = "opsqueue")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Chunk {
     pub submission_id: SubmissionId,
@@ -258,7 +258,7 @@ impl Chunk {
 
 /// Wrapper for the internal Opsqueue Chunk datatype
 /// Note that it also includes some fields originating from the Submission
-#[pyclass(frozen, get_all, module = "opsqueue")]
+#[pyclass(from_py_object, frozen, get_all, module = "opsqueue")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ChunkFailed {
     pub submission_id: SubmissionId,
@@ -331,7 +331,7 @@ impl From<opsqueue::common::submission::SubmissionCancelled> for SubmissionCance
     }
 }
 
-#[pyclass(frozen, module = "opsqueue")]
+#[pyclass(from_py_object, frozen, module = "opsqueue")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SubmissionStatus {
     InProgress {
@@ -378,7 +378,7 @@ impl SubmissionStatus {
     }
 }
 
-#[pyclass(frozen, get_all, module = "opsqueue")]
+#[pyclass(from_py_object, frozen, get_all, module = "opsqueue")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Submission {
     pub id: SubmissionId,
@@ -444,7 +444,7 @@ impl SubmissionCancelled {
     }
 }
 
-#[pyclass(frozen, get_all, module = "opsqueue")]
+#[pyclass(from_py_object, frozen, get_all, module = "opsqueue")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SubmissionCompleted {
     pub id: SubmissionId,
@@ -454,7 +454,7 @@ pub struct SubmissionCompleted {
     pub completed_at: DateTime<Utc>,
 }
 
-#[pyclass(frozen, get_all, module = "opsqueue")]
+#[pyclass(from_py_object, frozen, get_all, module = "opsqueue")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SubmissionFailed {
     pub id: SubmissionId,
@@ -466,7 +466,7 @@ pub struct SubmissionFailed {
     pub failed_chunk_id: u64,
 }
 
-#[pyclass(frozen, get_all, module = "opsqueue")]
+#[pyclass(from_py_object, frozen, get_all, module = "opsqueue")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SubmissionCancelled {
     pub id: SubmissionId,
@@ -479,7 +479,7 @@ pub struct SubmissionCancelled {
 
 /// Submission could not be cancelled because it was already completed, failed
 /// or cancelled.
-#[pyclass(frozen, module = "opsqueue")]
+#[pyclass(from_py_object, frozen, module = "opsqueue")]
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum SubmissionNotCancellable {
     Completed {

--- a/libs/opsqueue_python/src/common.rs
+++ b/libs/opsqueue_python/src/common.rs
@@ -123,7 +123,7 @@ impl Debug for Strategy {
             Strategy::PreferDistinct {
                 meta_key,
                 underlying,
-            } => Python::with_gil(|py| {
+            } => Python::attach(|py| {
                 let underlying = underlying.borrow(py);
                 f.debug_struct("Strategy.PreferDistinct")
                     .field("meta_key", meta_key)
@@ -146,7 +146,7 @@ impl From<strategy::Strategy> for Strategy {
             } => {
                 let underlying = Strategy::from(*underlying);
                 let underlying =
-                    Python::with_gil(|py| Py::new(py, underlying)).expect("A valid Strategy");
+                    Python::attach(|py| Py::new(py, underlying)).expect("A valid Strategy");
                 Strategy::PreferDistinct {
                     meta_key,
                     underlying,
@@ -537,7 +537,7 @@ where
 pub async fn check_signals_in_background() -> FatalPythonException {
     loop {
         tokio::time::sleep(SIGNAL_CHECK_INTERVAL).await;
-        let res = Python::with_gil(|py| {
+        let res = Python::attach(|py| {
             if let Err(err) = py.check_signals() {
                 // A signal was triggered
                 Some(err)
@@ -588,7 +588,7 @@ pub fn start_runtime() -> Arc<tokio::runtime::Runtime> {
 ///
 /// c.f. <https://pyo3.rs/main/doc/pyo3/types/trait.pytracebackmethods>
 pub fn format_pyerr(err: &PyErr) -> String {
-    Python::with_gil(|py| {
+    Python::attach(|py| {
         let msg: Option<String> = (|| {
             let traceback = err.traceback(py)?;
             let traceback_str = traceback

--- a/libs/opsqueue_python/src/producer.rs
+++ b/libs/opsqueue_python/src/producer.rs
@@ -92,7 +92,7 @@ impl ProducerClient {
         &self,
         py: Python<'_>,
     ) -> CPyResult<String, E<FatalPythonException, InternalProducerClientError>> {
-        py.allow_threads(|| {
+        py.detach(|| {
             self.block_unless_interrupted(async {
                 self.producer_client
                     .server_version()
@@ -109,7 +109,7 @@ impl ProducerClient {
         &self,
         py: Python<'_>,
     ) -> CPyResult<u32, E<FatalPythonException, InternalProducerClientError>> {
-        py.allow_threads(|| {
+        py.detach(|| {
             self.block_unless_interrupted(async {
                 self.producer_client
                     .count_submissions()
@@ -137,7 +137,7 @@ impl ProducerClient {
             InternalProducerClientError
         ],
     > {
-        py.allow_threads(|| {
+        py.detach(|| {
             self.block_unless_interrupted(async {
                 self.producer_client
                     .cancel_submission(id.into())
@@ -159,7 +159,7 @@ impl ProducerClient {
         id: SubmissionId,
     ) -> CPyResult<Option<SubmissionStatus>, E<FatalPythonException, InternalProducerClientError>>
     {
-        py.allow_threads(|| {
+        py.detach(|| {
             self.block_unless_interrupted(async {
                 self.producer_client
                     .get_submission(id.into())
@@ -179,7 +179,7 @@ impl ProducerClient {
         py: Python<'_>,
         prefix: &str,
     ) -> CPyResult<Option<SubmissionId>, E<FatalPythonException, InternalProducerClientError>> {
-        py.allow_threads(|| {
+        py.detach(|| {
             self.block_unless_interrupted(async {
                 self.producer_client
                     .lookup_submission_id_by_prefix(prefix)
@@ -204,7 +204,7 @@ impl ProducerClient {
     ) -> CPyResult<SubmissionId, E<FatalPythonException, InternalProducerClientError>> {
         let strategic_metadata = Default::default();
 
-        py.allow_threads(|| {
+        py.detach(|| {
             let submission = opsqueue::producer::InsertSubmission {
                 chunk_size: chunk_size.map(|n| chunk::ChunkSize(n as i64)),
                 chunk_contents: ChunkContents::Direct {
@@ -244,12 +244,12 @@ impl ProducerClient {
         // This function is split into two parts.
         // For the upload to object storage, we need the GIL as we run the python iterator to completion.
         // For the second part, where we send the submission to the queue, we no longer need the GIL (and unlock it to allow logging later).
-        py.allow_threads(|| {
+        py.detach(|| {
             let prefix = uuid::Uuid::now_v7().to_string();
             tracing::debug!("Uploading submission chunks to object store subfolder {prefix}...");
             let chunk_count = self.block_unless_interrupted(async {
                     let chunk_contents = std::iter::from_fn(move || {
-                        Python::with_gil(|py|
+                        Python::attach(|py|
                             chunk_contents.bind(py).clone().next()
                                 .map(|item| item.and_then(
                                     |item| item.extract()).map_err(Into::into)))
@@ -299,7 +299,7 @@ impl ProducerClient {
             InternalProducerClientError,
         ],
     > {
-        py.allow_threads(|| {
+        py.detach(|| {
             self.block_unless_interrupted(async move {
                 match self
                     .maybe_stream_completed_submission(id)
@@ -378,7 +378,7 @@ impl ProducerClient {
             InternalProducerClientError
         ],
     > {
-        py.allow_threads(|| {
+        py.detach(|| {
             self.block_unless_interrupted(async move {
                 self.stream_completed_submission_chunks(submission_id).await
             })
@@ -394,7 +394,7 @@ impl ProducerClient {
         let _tokio_active_runtime_guard = me.runtime.enter();
         async_util::future_into_py(
             py,
-            async_util::async_allow_threads(Box::pin(async move {
+            async_util::async_detach(Box::pin(async move {
                 match me.stream_completed_submission_chunks(submission_id).await {
                     Ok(iter) => {
                         let async_iter = PyChunksAsyncIter::from(iter);
@@ -525,7 +525,7 @@ impl PyChunksIter {
     fn __next__(&self, py: Python<'_>) -> Option<CPyResult<Vec<u8>, ChunkRetrievalError>> {
         // The only time we need the GIL is when turning the result back.
         // By unlocking here, we reduce the chance of deadlocks.
-        py.allow_threads(move || {
+        py.detach(move || {
             let runtime = self.runtime.clone();
             let stream = self.stream.clone();
             runtime.block_on(async {
@@ -573,7 +573,7 @@ impl PyChunksAsyncIter {
             py,
             // The only time we need the GIL is when turning the result into Python datatypes.
             // By unlocking here, we reduce the chance of deadlocks.
-            async_util::async_allow_threads(Box::pin(async move {
+            async_util::async_detach(Box::pin(async move {
                 // We lock the stream in a separate Tokio task
                 // that explicitly runs on the runtime thread rather than on the main Python thread.
                 // This reduces the possibility for deadlocks even further.

--- a/libs/opsqueue_python/src/producer.rs
+++ b/libs/opsqueue_python/src/producer.rs
@@ -34,7 +34,7 @@ create_exception!(opsqueue_internal, ProducerClientError, PyException);
 const SUBMISSION_POLLING_INTERVAL: Duration = Duration::from_millis(5000);
 
 // NOTE: ProducerClient is reasonably cheap to clone, as most of its fields are behind Arcs.
-#[pyclass(module = "opsqueue")]
+#[pyclass(from_py_object, module = "opsqueue")]
 #[derive(Debug, Clone)]
 pub struct ProducerClient {
     producer_client: ActualClient,


### PR DESCRIPTION
This PR includes 3 commits. For each commit simply bumped the minor version of pyo3 then addressed the compiler deprecation warnings and errors and ensured that the test-suite still passed.

@Qqwy while a ✅ from the compiler and test-suite are good signs, I'm not entirely confident whether the code in `async_util` is what we want, would suggest review keenly 🙏🏻 