### PR TITLE
Nix: Skip `cargo check` for `opsqueue` and `opsqueue_python` when building release

### DIFF
--- a/libs/opsqueue_python/opsqueue_python.nix
+++ b/libs/opsqueue_python/opsqueue_python.nix
@@ -63,7 +63,10 @@ let
     cargoExtraArgs = "--package opsqueue_python";
     doCheck = false;
   };
-  cargoArtifacts = craneLib.buildDepsOnly (commonArgs // { pname = pname; });
+  # The `cargo build` still catches the same errors as `cargo check`. The `nix build` executes them
+  # serially, this is the slowest part on CI. We have other CI linting steps, i.e. `cargo clippy`,
+  # that report these errors earlier.
+  cargoArtifacts = craneLib.buildDepsOnly (commonArgs // { cargoCheckCommand = "true"; });
 
   wheelTail = "py3-abi3-linux_x86_64";
   wheelName = "opsqueue-${version}-${wheelTail}.whl";

--- a/opsqueue/opsqueue.nix
+++ b/opsqueue/opsqueue.nix
@@ -16,14 +16,17 @@ let
   sources = import ../nix/sources.nix;
   crane = import sources.crane { pkgs = pkgs; };
   craneLib = crane.overrideToolchain (pkgs: rustToolchain);
-  extraFileFilter = path: _type: builtins.match "^.*\.(db|sql)$" path != null;
-  fileFilter = path: type: (extraFileFilter path type) || (craneLib.filterCargoSources path type);
+
+  # Only the files necessary to build the Rust-side and cache dependencies
+  sqlFileFilter = path: _type: builtins.match "^.*\.(db|sql)$" path != null;
+  rustCrateFileFilter =
+    path: type: (sqlFileFilter path type) || (craneLib.filterCargoSources path type);
 
   # src = craneLib.cleanCargoSource ../.;
   src = lib.cleanSourceWith {
     src = ../.;
     name = "opsqueue";
-    filter = fileFilter;
+    filter = rustCrateFileFilter;
   };
 
   crateName = craneLib.crateNameFromCargoToml { cargoToml = ./Cargo.toml; };
@@ -37,7 +40,10 @@ let
     cargoExtraArgs = "--package opsqueue";
     doCheck = true;
   };
-  cargoArtifacts = craneLib.buildDepsOnly commonArgs;
+  # The `cargo build` still catches the same errors as `cargo check`. The `nix build` executes them
+  # serially, this is the slowest part on CI. We have other CI linting steps, i.e. `cargo clippy`,
+  # that report these errors earlier.
+  cargoArtifacts = craneLib.buildDepsOnly (commonArgs // { cargoCheckCommand = "true"; });
 in
 craneLib.buildPackage (
   commonArgs


### PR DESCRIPTION
This prevents two sequential phases in our Nix builds (which are the slowest parts of CI we have).