### PR TITLE
Pass `reserver_id`s to SQLite to pre-filter the queried `chunks`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2274,6 +2274,7 @@ dependencies = [
  "humantime",
  "insta",
  "itertools 0.14.0",
+ "libsqlite3-sys",
  "moka",
  "moro-local",
  "object_store",

--- a/opsqueue/Cargo.toml
+++ b/opsqueue/Cargo.toml
@@ -33,6 +33,7 @@ ux = "0.1.6"
 anyhow = "1.0.102"
 # Database:
 sqlx = { version = "0.8.2", features = ["sqlite", "runtime-tokio", "chrono"], optional = true }
+libsqlite3-sys = { version = "0.30.1", optional = true }
 # Serialization:
 serde = { version = "1.0.203", features = ["derive"] }
 serde_json = "1.0.149"
@@ -96,6 +97,7 @@ assert_matches = { version = "1.5.0" }
 # Dependencies only in use by the server-logic:
 server-logic = [
     "dep:sqlx",
+    "dep:libsqlite3-sys",
     "dep:opentelemetry-otlp",
     "dep:opentelemetry-semantic-conventions",
     "dep:moka",

--- a/opsqueue/src/common/chunk.rs
+++ b/opsqueue/src/common/chunk.rs
@@ -124,6 +124,18 @@ impl From<ChunkIndex> for i64 {
     }
 }
 
+impl TryFrom<i64> for ChunkIndex {
+    type Error = crate::common::errors::TryFromIntError;
+
+    fn try_from(value: i64) -> Result<Self, Self::Error> {
+        if value < 0 {
+            return Err(crate::common::errors::TryFromIntError(()));
+        }
+
+        Ok(Self(u63::new(value as u64)))
+    }
+}
+
 impl TryFrom<u64> for ChunkIndex {
     type Error = crate::common::errors::TryFromIntError;
     fn try_from(value: u64) -> Result<Self, Self::Error> {

--- a/opsqueue/src/common/submission.rs
+++ b/opsqueue/src/common/submission.rs
@@ -532,12 +532,10 @@ pub mod db {
             r#"
             SELECT id AS "id: SubmissionId" FROM submissions WHERE prefix = $1
             UNION ALL
-            SELECT id AS "id: SubmissionId" FROM submissions_completed WHERE prefix = $2
+            SELECT id AS "id: SubmissionId" FROM submissions_completed WHERE prefix = $1
             UNION ALL
-            SELECT id AS "id: SubmissionId" FROM submissions_failed WHERE prefix = $3
+            SELECT id AS "id: SubmissionId" FROM submissions_failed WHERE prefix = $1
             "#,
-            prefix,
-            prefix,
             prefix
         )
         .fetch_optional(conn.get_inner())

--- a/opsqueue/src/consumer/dispatcher/mod.rs
+++ b/opsqueue/src/consumer/dispatcher/mod.rs
@@ -6,7 +6,7 @@ use crate::{
         chunk::{Chunk, ChunkId, ChunkIndex},
         submission::{Submission, SubmissionId},
     },
-    db::{Connection, Pool, ReaderPool, magic::Bool},
+    db::{magic::Bool, Connection, Pool, ReaderPool},
 };
 use futures::stream::{StreamExt as _, TryStreamExt as _};
 use libsqlite3_sys as ffi;

--- a/opsqueue/src/consumer/dispatcher/mod.rs
+++ b/opsqueue/src/consumer/dispatcher/mod.rs
@@ -3,12 +3,13 @@ pub mod reserver;
 
 use crate::{
     common::{
-        chunk::{Chunk, ChunkId},
-        submission::Submission,
+        chunk::{Chunk, ChunkId, ChunkIndex},
+        submission::{Submission, SubmissionId},
     },
-    db::{magic::Bool, Connection, Pool, ReaderPool},
+    db::{Connection, Pool, ReaderPool, magic::Bool},
 };
 use futures::stream::{StreamExt as _, TryStreamExt as _};
+use libsqlite3_sys as ffi;
 use metastate::MetaState;
 use reserver::Reserver;
 use sqlx::QueryBuilder;
@@ -20,6 +21,63 @@ use std::sync::Arc;
 
 use super::strategy;
 use crate::common::StrategicMetadataMap;
+
+unsafe extern "C" fn sqlite_reserved_chunk_lookup(
+    context: *mut ffi::sqlite3_context,
+    n_args: i32,
+    args: *mut *mut ffi::sqlite3_value,
+) {
+    if n_args != 2 {
+        tracing::error!(
+            n_args,
+            "opsqueue_is_reserved called with unexpected argument count"
+        );
+        // Fail open: this callback is an optimization only.
+        ffi::sqlite3_result_int(context, 0);
+        return;
+    }
+
+    let user_data = ffi::sqlite3_user_data(context) as *const Reserver<ChunkId, ChunkId>;
+    if user_data.is_null() {
+        tracing::error!("opsqueue_is_reserved called without registered reserver user_data");
+        // Fail open: this callback is an optimization only.
+        ffi::sqlite3_result_int(context, 0);
+        return;
+    }
+
+    let submission_id_raw = ffi::sqlite3_value_int64(*args.add(0));
+    let chunk_index_raw = ffi::sqlite3_value_int64(*args.add(1));
+
+    let Ok(submission_id) = SubmissionId::try_from(submission_id_raw) else {
+        tracing::error!(
+            submission_id_raw,
+            "opsqueue_is_reserved got invalid submission_id"
+        );
+        // Fail open: this callback is an optimization only.
+        ffi::sqlite3_result_int(context, 0);
+        return;
+    };
+    let Ok(chunk_index) = ChunkIndex::try_from(chunk_index_raw) else {
+        tracing::error!(
+            chunk_index_raw,
+            "opsqueue_is_reserved got invalid chunk_index"
+        );
+        // Fail open: this callback is an optimization only.
+        ffi::sqlite3_result_int(context, 0);
+        return;
+    };
+
+    let chunk_id = ChunkId::from((submission_id, chunk_index));
+    let is_reserved = (*user_data).is_reserved(&chunk_id);
+    ffi::sqlite3_result_int(context, i32::from(is_reserved));
+}
+
+unsafe extern "C" fn sqlite_reserved_chunk_lookup_destructor(ptr: *mut std::ffi::c_void) {
+    if ptr.is_null() {
+        return;
+    }
+    let _boxed: Box<Reserver<ChunkId, ChunkId>> = Box::from_raw(ptr.cast());
+}
 
 #[derive(Debug, Clone)]
 pub struct Dispatcher {
@@ -66,6 +124,8 @@ impl Dispatcher {
         stale_chunks_notifier: &UnboundedSender<ChunkId>,
     ) -> Result<Vec<(Chunk, Submission)>, sqlx::Error> {
         let mut conn = pool.reader_conn().await?;
+        self.register_reserved_chunk_lookup(conn.get_inner())
+            .await?;
         let mut query_builder = QueryBuilder::new("");
         let stream = strategy
             .build_query(&mut query_builder, &self.metastate)
@@ -77,6 +137,43 @@ impl Dispatcher {
             .take(limit)
             .try_collect()
             .await
+    }
+
+    async fn register_reserved_chunk_lookup(
+        &self,
+        conn: &mut sqlx::SqliteConnection,
+    ) -> Result<(), sqlx::Error> {
+        let mut handle = conn.lock_handle().await?;
+        let sqlite = handle.as_raw_handle().as_ptr();
+        let function_name = b"opsqueue_is_reserved\0";
+
+        // Register the current reserver state on this connection.
+        // Re-registering replaces any previous callback on this handle.
+        let user_data = Box::new(self.reserver.clone());
+        let user_data = Box::into_raw(user_data).cast::<std::ffi::c_void>();
+
+        let rc = unsafe {
+            ffi::sqlite3_create_function_v2(
+                sqlite,
+                function_name.as_ptr().cast(),
+                2,
+                ffi::SQLITE_UTF8,
+                user_data,
+                Some(sqlite_reserved_chunk_lookup),
+                None,
+                None,
+                Some(sqlite_reserved_chunk_lookup_destructor),
+            )
+        };
+
+        if rc != ffi::SQLITE_OK {
+            unsafe { sqlite_reserved_chunk_lookup_destructor(user_data) };
+            return Err(sqlx::Error::Protocol(format!(
+                "sqlite3_create_function_v2 failed with rc={rc}"
+            )));
+        }
+
+        Ok(())
     }
 
     async fn reserve_chunk<E>(
@@ -142,5 +239,60 @@ impl Dispatcher {
     pub fn run_pending_tasks_periodically(&self, cancellation_token: CancellationToken) {
         self.reserver
             .run_pending_tasks_periodically(cancellation_token);
+    }
+}
+
+#[cfg(test)]
+#[cfg(feature = "server-logic")]
+mod test {
+    use super::*;
+    use crate::common::chunk::ChunkId;
+    use crate::common::chunk::ChunkSize;
+    use crate::db::DBPools;
+    use tokio::sync::mpsc::unbounded_channel;
+    use ux::u63;
+
+    #[sqlx::test]
+    async fn fetch_and_reserve_chunks_excludes_already_reserved(db: sqlx::SqlitePool) {
+        let pools = DBPools::from_test_pool(&db);
+        let dispatcher = Dispatcher::new(Duration::from_secs(60));
+        let (stale_chunks_notifier, mut _stale_chunks_receiver) = unbounded_channel::<ChunkId>();
+
+        let mut writer_conn = pools.writer_conn().await.unwrap();
+        let submission_id = crate::common::submission::db::insert_submission_from_chunks(
+            None,
+            vec![Some("a".into()), Some("b".into()), Some("c".into())],
+            None,
+            StrategicMetadataMap::default(),
+            ChunkSize::default(),
+            &mut writer_conn,
+        )
+        .await
+        .unwrap();
+
+        let pre_reserved_chunk = ChunkId::from((submission_id, u63::new(0).into()));
+        dispatcher
+            .reserver()
+            .try_reserve(
+                pre_reserved_chunk,
+                pre_reserved_chunk,
+                &stale_chunks_notifier,
+            )
+            .expect("precondition: pre-reserving chunk should succeed");
+
+        let reserved = dispatcher
+            .fetch_and_reserve_chunks(
+                pools.reader_pool(),
+                strategy::Strategy::Oldest,
+                10,
+                &stale_chunks_notifier,
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(reserved.len(), 2);
+        assert!(reserved.iter().all(|(chunk, _submission)| {
+            ChunkId::from((chunk.submission_id, chunk.chunk_index)) != pre_reserved_chunk
+        }));
     }
 }

--- a/opsqueue/src/consumer/dispatcher/reserver.rs
+++ b/opsqueue/src/consumer/dispatcher/reserver.rs
@@ -82,6 +82,11 @@ where
         }
     }
 
+    /// Returns whether a key currently has an active reservation.
+    pub fn is_reserved(&self, key: &K) -> bool {
+        self.reservations.contains_key(key)
+    }
+
     /// Removes a particular key-val from the reserver.
     /// Afterwards, it is possible to reserve it again.
     ///

--- a/opsqueue/src/consumer/strategy.rs
+++ b/opsqueue/src/consumer/strategy.rs
@@ -106,13 +106,13 @@ pub type ChunkStream<'a> = BoxStream<'a, Result<Chunk, sqlx::Error>>;
 pub mod test {
     use itertools::Itertools;
     use libsqlite3_sys as ffi;
-    use sqlformat::{FormatOptions, QueryParams, format};
+    use sqlformat::{format, FormatOptions, QueryParams};
     use sqlx::Row;
     use sqlx::{QueryBuilder, Sqlite, SqliteConnection};
 
     use super::*;
-    use crate::common::StrategicMetadataMap;
     use crate::common::chunk::ChunkSize;
+    use crate::common::StrategicMetadataMap;
 
     unsafe extern "C" fn sqlite_reserved_chunk_lookup_noop(
         context: *mut ffi::sqlite3_context,

--- a/opsqueue/src/consumer/strategy.rs
+++ b/opsqueue/src/consumer/strategy.rs
@@ -40,14 +40,22 @@ impl Strategy {
     ) -> &'a mut QueryBuilder<'a, Sqlite> {
         use Strategy::*;
         match self {
-            Oldest => qb.push("SELECT * FROM chunks ORDER BY submission_id ASC"),
-            Newest => qb.push("SELECT * FROM chunks ORDER BY submission_id DESC"),
+            Oldest => qb
+                .push("SELECT * FROM chunks")
+                .push(" WHERE opsqueue_is_reserved(submission_id, chunk_index) = 0")
+                .push(" ORDER BY submission_id ASC"),
+            Newest => qb
+                .push("SELECT * FROM chunks")
+                .push(" WHERE opsqueue_is_reserved(submission_id, chunk_index) = 0")
+                .push(" ORDER BY submission_id DESC"),
             Random => {
                 let random_offset: u16 = rand::random();
                 qb.push("SELECT * FROM chunks WHERE random_order >= ")
                     .push_bind(random_offset)
+                    .push(" AND opsqueue_is_reserved(submission_id, chunk_index) = 0")
                     .push(" UNION ALL SELECT * FROM chunks WHERE random_order < ")
                     .push_bind(random_offset)
+                    .push(" AND opsqueue_is_reserved(submission_id, chunk_index) = 0")
             }
 
             PreferDistinct {
@@ -96,14 +104,43 @@ pub type ChunkStream<'a> = BoxStream<'a, Result<Chunk, sqlx::Error>>;
 #[cfg(test)]
 #[cfg(feature = "server-logic")]
 pub mod test {
-    use crate::common::chunk::ChunkSize;
-    use crate::common::StrategicMetadataMap;
-
-    use super::*;
     use itertools::Itertools;
-    use sqlformat::{format, FormatOptions, QueryParams};
+    use libsqlite3_sys as ffi;
+    use sqlformat::{FormatOptions, QueryParams, format};
     use sqlx::Row;
     use sqlx::{QueryBuilder, Sqlite, SqliteConnection};
+
+    use super::*;
+    use crate::common::StrategicMetadataMap;
+    use crate::common::chunk::ChunkSize;
+
+    unsafe extern "C" fn sqlite_reserved_chunk_lookup_noop(
+        context: *mut ffi::sqlite3_context,
+        _n_args: i32,
+        _args: *mut *mut ffi::sqlite3_value,
+    ) {
+        ffi::sqlite3_result_int(context, 0);
+    }
+
+    async fn register_reserved_lookup_noop(conn: &mut SqliteConnection) {
+        let mut handle = conn.lock_handle().await.unwrap();
+        let sqlite = handle.as_raw_handle().as_ptr();
+        let function_name = b"opsqueue_is_reserved\0";
+        let rc = unsafe {
+            ffi::sqlite3_create_function_v2(
+                sqlite,
+                function_name.as_ptr().cast(),
+                2,
+                ffi::SQLITE_UTF8,
+                std::ptr::null_mut(),
+                Some(sqlite_reserved_chunk_lookup_noop),
+                None,
+                None,
+                None,
+            )
+        };
+        assert_eq!(rc, ffi::SQLITE_OK, "register opsqueue_is_reserved failed");
+    }
 
     async fn explain(
         qb: &mut sqlx::QueryBuilder<'_, Sqlite>,
@@ -134,6 +171,7 @@ pub mod test {
     #[sqlx::test]
     pub async fn test_query_plan_oldest(db: sqlx::SqlitePool) {
         let mut conn = db.acquire().await.unwrap();
+        register_reserved_lookup_noop(&mut conn).await;
         let mut qb = QueryBuilder::new("");
         let metastate = MetaState::default();
 
@@ -145,6 +183,8 @@ pub mod test {
           *
         FROM
           chunks
+        WHERE
+          opsqueue_is_reserved(submission_id, chunk_index) = 0
         ORDER BY
           submission_id ASC
         ");
@@ -157,6 +197,7 @@ pub mod test {
     #[sqlx::test]
     pub async fn test_query_plan_newest(db: sqlx::SqlitePool) {
         let mut conn = db.acquire().await.unwrap();
+        register_reserved_lookup_noop(&mut conn).await;
         let mut qb = QueryBuilder::new("");
         let metastate = MetaState::default();
 
@@ -168,6 +209,8 @@ pub mod test {
           *
         FROM
           chunks
+        WHERE
+          opsqueue_is_reserved(submission_id, chunk_index) = 0
         ORDER BY
           submission_id DESC
         ");
@@ -180,6 +223,7 @@ pub mod test {
     #[sqlx::test]
     pub async fn test_query_plan_random(db: sqlx::SqlitePool) {
         let mut conn = db.acquire().await.unwrap();
+        register_reserved_lookup_noop(&mut conn).await;
         let metastate = MetaState::default();
         let mut qb = QueryBuilder::new("");
 
@@ -193,6 +237,7 @@ pub mod test {
           chunks
         WHERE
           random_order >= ?
+          AND opsqueue_is_reserved(submission_id, chunk_index) = 0
         UNION ALL
         SELECT
           *
@@ -200,6 +245,7 @@ pub mod test {
           chunks
         WHERE
           random_order < ?
+          AND opsqueue_is_reserved(submission_id, chunk_index) = 0
         ");
 
         let explained = explain(qb, &mut conn).await;
@@ -208,8 +254,8 @@ pub mod test {
         1, 0, COMPOUND QUERY
         2, 1, LEFT-MOST SUBQUERY
         5, 2, SEARCH chunks USING INDEX random_chunks_order (random_order>?)
-        22, 1, UNION ALL
-        25, 22, SEARCH chunks USING INDEX random_chunks_order (random_order<?)
+        26, 1, UNION ALL
+        29, 26, SEARCH chunks USING INDEX random_chunks_order (random_order<?)
         ");
     }
 
@@ -217,6 +263,7 @@ pub mod test {
     pub async fn test_query_plan_prefer_distinct_oldest(db: sqlx::SqlitePool) {
         use Strategy::*;
         let mut conn = db.acquire().await.unwrap();
+        register_reserved_lookup_noop(&mut conn).await;
         let metastate = MetaState::default();
 
         let strategy = PreferDistinct {
@@ -234,6 +281,8 @@ pub mod test {
             *
           FROM
             chunks
+          WHERE
+            opsqueue_is_reserved(submission_id, chunk_index) = 0
           ORDER BY
             submission_id ASC
         ),
@@ -286,16 +335,16 @@ pub mod test {
         1, 0, COMPOUND QUERY
         2, 1, LEFT-MOST SUBQUERY
         5, 2, SCAN chunks
-        8, 2, CORRELATED SCALAR SUBQUERY 4
-        12, 8, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        18, 8, LIST SUBQUERY 2
-        20, 18, SCAN json_each VIRTUAL TABLE INDEX 0:
-        63, 1, UNION ALL
-        66, 63, SCAN chunks
-        69, 63, CORRELATED SCALAR SUBQUERY 6
-        73, 69, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        79, 69, LIST SUBQUERY 2
-        81, 79, SCAN json_each VIRTUAL TABLE INDEX 0:
+        12, 2, CORRELATED SCALAR SUBQUERY 4
+        16, 12, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        22, 12, LIST SUBQUERY 2
+        24, 22, SCAN json_each VIRTUAL TABLE INDEX 0:
+        67, 1, UNION ALL
+        70, 67, SCAN chunks
+        77, 67, CORRELATED SCALAR SUBQUERY 6
+        81, 77, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        87, 77, LIST SUBQUERY 2
+        89, 87, SCAN json_each VIRTUAL TABLE INDEX 0:
         ");
     }
 
@@ -303,6 +352,7 @@ pub mod test {
     pub async fn test_query_plan_prefer_distinct_newest(db: sqlx::SqlitePool) {
         use Strategy::*;
         let mut conn = db.acquire().await.unwrap();
+        register_reserved_lookup_noop(&mut conn).await;
         let metastate = MetaState::default();
 
         let strategy = PreferDistinct {
@@ -320,6 +370,8 @@ pub mod test {
             *
           FROM
             chunks
+          WHERE
+            opsqueue_is_reserved(submission_id, chunk_index) = 0
           ORDER BY
             submission_id DESC
         ),
@@ -372,16 +424,16 @@ pub mod test {
         1, 0, COMPOUND QUERY
         2, 1, LEFT-MOST SUBQUERY
         5, 2, SCAN chunks
-        8, 2, CORRELATED SCALAR SUBQUERY 4
-        12, 8, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        18, 8, LIST SUBQUERY 2
-        20, 18, SCAN json_each VIRTUAL TABLE INDEX 0:
-        63, 1, UNION ALL
-        66, 63, SCAN chunks
-        69, 63, CORRELATED SCALAR SUBQUERY 6
-        73, 69, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        79, 69, LIST SUBQUERY 2
-        81, 79, SCAN json_each VIRTUAL TABLE INDEX 0:
+        12, 2, CORRELATED SCALAR SUBQUERY 4
+        16, 12, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        22, 12, LIST SUBQUERY 2
+        24, 22, SCAN json_each VIRTUAL TABLE INDEX 0:
+        67, 1, UNION ALL
+        70, 67, SCAN chunks
+        77, 67, CORRELATED SCALAR SUBQUERY 6
+        81, 77, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        87, 77, LIST SUBQUERY 2
+        89, 87, SCAN json_each VIRTUAL TABLE INDEX 0:
         ");
     }
 
@@ -389,6 +441,7 @@ pub mod test {
     pub async fn test_query_plan_prefer_distinct_random(db: sqlx::SqlitePool) {
         use Strategy::*;
         let mut conn = db.acquire().await.unwrap();
+        register_reserved_lookup_noop(&mut conn).await;
         let metastate = MetaState::default();
 
         let strategy = PreferDistinct {
@@ -408,6 +461,7 @@ pub mod test {
             chunks
           WHERE
             random_order >= ?
+            AND opsqueue_is_reserved(submission_id, chunk_index) = 0
           UNION ALL
           SELECT
             *
@@ -415,6 +469,7 @@ pub mod test {
             chunks
           WHERE
             random_order < ?
+            AND opsqueue_is_reserved(submission_id, chunk_index) = 0
         ),
         taken_company_id AS (
           SELECT
@@ -467,30 +522,30 @@ pub mod test {
         3, 2, COMPOUND QUERY
         4, 3, LEFT-MOST SUBQUERY
         7, 4, SEARCH chunks USING INDEX random_chunks_order (random_order>?)
-        16, 4, CORRELATED SCALAR SUBQUERY 5
-        20, 16, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        26, 16, LIST SUBQUERY 3
-        28, 26, SCAN json_each VIRTUAL TABLE INDEX 0:
-        63, 3, UNION ALL
-        66, 63, SEARCH chunks USING INDEX random_chunks_order (random_order<?)
-        76, 63, CORRELATED SCALAR SUBQUERY 5
-        80, 76, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        86, 76, LIST SUBQUERY 3
-        88, 86, SCAN json_each VIRTUAL TABLE INDEX 0:
-        123, 3, UNION ALL
-        124, 123, COMPOUND QUERY
-        125, 124, LEFT-MOST SUBQUERY
-        128, 125, SEARCH chunks USING INDEX random_chunks_order (random_order>?)
-        137, 125, CORRELATED SCALAR SUBQUERY 7
-        141, 137, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        147, 137, LIST SUBQUERY 3
-        149, 147, SCAN json_each VIRTUAL TABLE INDEX 0:
-        184, 124, UNION ALL
-        187, 184, SEARCH chunks USING INDEX random_chunks_order (random_order<?)
-        197, 184, CORRELATED SCALAR SUBQUERY 7
-        201, 197, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        207, 197, LIST SUBQUERY 3
-        209, 207, SCAN json_each VIRTUAL TABLE INDEX 0:
+        20, 4, CORRELATED SCALAR SUBQUERY 5
+        24, 20, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        30, 20, LIST SUBQUERY 3
+        32, 30, SCAN json_each VIRTUAL TABLE INDEX 0:
+        67, 3, UNION ALL
+        70, 67, SEARCH chunks USING INDEX random_chunks_order (random_order<?)
+        84, 67, CORRELATED SCALAR SUBQUERY 5
+        88, 84, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        94, 84, LIST SUBQUERY 3
+        96, 94, SCAN json_each VIRTUAL TABLE INDEX 0:
+        131, 3, UNION ALL
+        132, 131, COMPOUND QUERY
+        133, 132, LEFT-MOST SUBQUERY
+        136, 133, SEARCH chunks USING INDEX random_chunks_order (random_order>?)
+        149, 133, CORRELATED SCALAR SUBQUERY 7
+        153, 149, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        159, 149, LIST SUBQUERY 3
+        161, 159, SCAN json_each VIRTUAL TABLE INDEX 0:
+        196, 132, UNION ALL
+        199, 196, SEARCH chunks USING INDEX random_chunks_order (random_order<?)
+        213, 196, CORRELATED SCALAR SUBQUERY 7
+        217, 213, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        223, 213, LIST SUBQUERY 3
+        225, 223, SCAN json_each VIRTUAL TABLE INDEX 0:
         ");
     }
 
@@ -498,6 +553,7 @@ pub mod test {
     pub async fn test_query_plan_prefer_distinct_nested(db: sqlx::SqlitePool) {
         use Strategy::*;
         let mut conn = db.acquire().await.unwrap();
+        register_reserved_lookup_noop(&mut conn).await;
         let metastate = MetaState::default();
 
         let strategy = PreferDistinct {
@@ -523,6 +579,7 @@ pub mod test {
               chunks
             WHERE
               random_order >= ?
+              AND opsqueue_is_reserved(submission_id, chunk_index) = 0
             UNION ALL
             SELECT
               *
@@ -530,6 +587,7 @@ pub mod test {
               chunks
             WHERE
               random_order < ?
+              AND opsqueue_is_reserved(submission_id, chunk_index) = 0
           ),
           taken_priority AS (
             SELECT
@@ -626,92 +684,92 @@ pub mod test {
         5, 4, COMPOUND QUERY
         6, 5, LEFT-MOST SUBQUERY
         9, 6, SEARCH chunks USING INDEX random_chunks_order (random_order>?)
-        18, 6, CORRELATED SCALAR SUBQUERY 5
-        22, 18, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        28, 18, LIST SUBQUERY 3
-        30, 28, SCAN json_each VIRTUAL TABLE INDEX 0:
-        57, 6, CORRELATED SCALAR SUBQUERY 11
-        61, 57, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        67, 57, LIST SUBQUERY 9
-        69, 67, SCAN json_each VIRTUAL TABLE INDEX 0:
-        104, 5, UNION ALL
-        107, 104, SEARCH chunks USING INDEX random_chunks_order (random_order<?)
-        117, 104, CORRELATED SCALAR SUBQUERY 5
-        121, 117, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        127, 117, LIST SUBQUERY 3
-        129, 127, SCAN json_each VIRTUAL TABLE INDEX 0:
-        156, 104, CORRELATED SCALAR SUBQUERY 11
-        160, 156, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        166, 156, LIST SUBQUERY 9
-        168, 166, SCAN json_each VIRTUAL TABLE INDEX 0:
-        203, 5, UNION ALL
-        204, 203, COMPOUND QUERY
-        205, 204, LEFT-MOST SUBQUERY
-        208, 205, SEARCH chunks USING INDEX random_chunks_order (random_order>?)
-        217, 205, CORRELATED SCALAR SUBQUERY 7
-        221, 217, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        227, 217, LIST SUBQUERY 3
-        229, 227, SCAN json_each VIRTUAL TABLE INDEX 0:
-        256, 205, CORRELATED SCALAR SUBQUERY 11
-        260, 256, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        266, 256, LIST SUBQUERY 9
-        268, 266, SCAN json_each VIRTUAL TABLE INDEX 0:
-        303, 204, UNION ALL
-        306, 303, SEARCH chunks USING INDEX random_chunks_order (random_order<?)
-        316, 303, CORRELATED SCALAR SUBQUERY 7
-        320, 316, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        326, 316, LIST SUBQUERY 3
-        328, 326, SCAN json_each VIRTUAL TABLE INDEX 0:
-        355, 303, CORRELATED SCALAR SUBQUERY 11
-        359, 355, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        365, 355, LIST SUBQUERY 9
-        367, 365, SCAN json_each VIRTUAL TABLE INDEX 0:
-        402, 204, UNION ALL
-        403, 402, COMPOUND QUERY
-        404, 403, LEFT-MOST SUBQUERY
-        405, 404, COMPOUND QUERY
-        406, 405, LEFT-MOST SUBQUERY
-        409, 406, SEARCH chunks USING INDEX random_chunks_order (random_order>?)
-        418, 406, CORRELATED SCALAR SUBQUERY 5
-        422, 418, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        428, 418, LIST SUBQUERY 3
-        430, 428, SCAN json_each VIRTUAL TABLE INDEX 0:
-        457, 406, CORRELATED SCALAR SUBQUERY 13
-        461, 457, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        467, 457, LIST SUBQUERY 9
-        469, 467, SCAN json_each VIRTUAL TABLE INDEX 0:
-        504, 405, UNION ALL
-        507, 504, SEARCH chunks USING INDEX random_chunks_order (random_order<?)
-        517, 504, CORRELATED SCALAR SUBQUERY 5
-        521, 517, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        527, 517, LIST SUBQUERY 3
-        529, 527, SCAN json_each VIRTUAL TABLE INDEX 0:
-        556, 504, CORRELATED SCALAR SUBQUERY 13
-        560, 556, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        566, 556, LIST SUBQUERY 9
-        568, 566, SCAN json_each VIRTUAL TABLE INDEX 0:
-        603, 405, UNION ALL
-        604, 603, COMPOUND QUERY
-        605, 604, LEFT-MOST SUBQUERY
-        608, 605, SEARCH chunks USING INDEX random_chunks_order (random_order>?)
-        617, 605, CORRELATED SCALAR SUBQUERY 7
-        621, 617, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        627, 617, LIST SUBQUERY 3
-        629, 627, SCAN json_each VIRTUAL TABLE INDEX 0:
-        656, 605, CORRELATED SCALAR SUBQUERY 13
-        660, 656, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        666, 656, LIST SUBQUERY 9
-        668, 666, SCAN json_each VIRTUAL TABLE INDEX 0:
-        703, 604, UNION ALL
-        706, 703, SEARCH chunks USING INDEX random_chunks_order (random_order<?)
-        716, 703, CORRELATED SCALAR SUBQUERY 7
-        720, 716, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        726, 716, LIST SUBQUERY 3
-        728, 726, SCAN json_each VIRTUAL TABLE INDEX 0:
-        755, 703, CORRELATED SCALAR SUBQUERY 13
-        759, 755, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
-        765, 755, LIST SUBQUERY 9
-        767, 765, SCAN json_each VIRTUAL TABLE INDEX 0:
+        22, 6, CORRELATED SCALAR SUBQUERY 5
+        26, 22, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        32, 22, LIST SUBQUERY 3
+        34, 32, SCAN json_each VIRTUAL TABLE INDEX 0:
+        61, 6, CORRELATED SCALAR SUBQUERY 11
+        65, 61, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        71, 61, LIST SUBQUERY 9
+        73, 71, SCAN json_each VIRTUAL TABLE INDEX 0:
+        108, 5, UNION ALL
+        111, 108, SEARCH chunks USING INDEX random_chunks_order (random_order<?)
+        125, 108, CORRELATED SCALAR SUBQUERY 5
+        129, 125, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        135, 125, LIST SUBQUERY 3
+        137, 135, SCAN json_each VIRTUAL TABLE INDEX 0:
+        164, 108, CORRELATED SCALAR SUBQUERY 11
+        168, 164, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        174, 164, LIST SUBQUERY 9
+        176, 174, SCAN json_each VIRTUAL TABLE INDEX 0:
+        211, 5, UNION ALL
+        212, 211, COMPOUND QUERY
+        213, 212, LEFT-MOST SUBQUERY
+        216, 213, SEARCH chunks USING INDEX random_chunks_order (random_order>?)
+        229, 213, CORRELATED SCALAR SUBQUERY 7
+        233, 229, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        239, 229, LIST SUBQUERY 3
+        241, 239, SCAN json_each VIRTUAL TABLE INDEX 0:
+        268, 213, CORRELATED SCALAR SUBQUERY 11
+        272, 268, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        278, 268, LIST SUBQUERY 9
+        280, 278, SCAN json_each VIRTUAL TABLE INDEX 0:
+        315, 212, UNION ALL
+        318, 315, SEARCH chunks USING INDEX random_chunks_order (random_order<?)
+        332, 315, CORRELATED SCALAR SUBQUERY 7
+        336, 332, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        342, 332, LIST SUBQUERY 3
+        344, 342, SCAN json_each VIRTUAL TABLE INDEX 0:
+        371, 315, CORRELATED SCALAR SUBQUERY 11
+        375, 371, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        381, 371, LIST SUBQUERY 9
+        383, 381, SCAN json_each VIRTUAL TABLE INDEX 0:
+        418, 212, UNION ALL
+        419, 418, COMPOUND QUERY
+        420, 419, LEFT-MOST SUBQUERY
+        421, 420, COMPOUND QUERY
+        422, 421, LEFT-MOST SUBQUERY
+        425, 422, SEARCH chunks USING INDEX random_chunks_order (random_order>?)
+        438, 422, CORRELATED SCALAR SUBQUERY 5
+        442, 438, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        448, 438, LIST SUBQUERY 3
+        450, 448, SCAN json_each VIRTUAL TABLE INDEX 0:
+        477, 422, CORRELATED SCALAR SUBQUERY 13
+        481, 477, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        487, 477, LIST SUBQUERY 9
+        489, 487, SCAN json_each VIRTUAL TABLE INDEX 0:
+        524, 421, UNION ALL
+        527, 524, SEARCH chunks USING INDEX random_chunks_order (random_order<?)
+        541, 524, CORRELATED SCALAR SUBQUERY 5
+        545, 541, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        551, 541, LIST SUBQUERY 3
+        553, 551, SCAN json_each VIRTUAL TABLE INDEX 0:
+        580, 524, CORRELATED SCALAR SUBQUERY 13
+        584, 580, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        590, 580, LIST SUBQUERY 9
+        592, 590, SCAN json_each VIRTUAL TABLE INDEX 0:
+        627, 421, UNION ALL
+        628, 627, COMPOUND QUERY
+        629, 628, LEFT-MOST SUBQUERY
+        632, 629, SEARCH chunks USING INDEX random_chunks_order (random_order>?)
+        645, 629, CORRELATED SCALAR SUBQUERY 7
+        649, 645, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        655, 645, LIST SUBQUERY 3
+        657, 655, SCAN json_each VIRTUAL TABLE INDEX 0:
+        684, 629, CORRELATED SCALAR SUBQUERY 13
+        688, 684, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        694, 684, LIST SUBQUERY 9
+        696, 694, SCAN json_each VIRTUAL TABLE INDEX 0:
+        731, 628, UNION ALL
+        734, 731, SEARCH chunks USING INDEX random_chunks_order (random_order<?)
+        748, 731, CORRELATED SCALAR SUBQUERY 7
+        752, 748, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        758, 748, LIST SUBQUERY 3
+        760, 758, SCAN json_each VIRTUAL TABLE INDEX 0:
+        787, 731, CORRELATED SCALAR SUBQUERY 13
+        791, 787, SEARCH submissions_metadata USING COVERING INDEX lookup_submission_by_metadata (metadata_key=? AND metadata_value=? AND submission_id=?)
+        797, 787, LIST SUBQUERY 9
+        799, 797, SCAN json_each VIRTUAL TABLE INDEX 0:
         ");
     }
 
@@ -741,6 +799,7 @@ pub mod test {
         .unwrap();
 
         let mut conn = db_pools.reader_conn().await.unwrap();
+        register_reserved_lookup_noop(conn.get_inner()).await;
         let mut query_builder = QueryBuilder::default();
         let vals1: Vec<Chunk> = Strategy::Random
             .build_query(&mut query_builder, &Default::default())


### PR DESCRIPTION
This uses the fact that SQLite query engine lives in the same process as the calling Rust code to pass the integers directly into the query via SQL-FFI.

This can be extended to the `metastate` as well so we don't need to serialize to JSON in order to use the data in the query itself.