### PR TITLE
Python tooling shouldn't look at `pyproject.toml` outside the repository

### DIFF
--- a/extra/experimentation/shell.nix
+++ b/extra/experimentation/shell.nix
@@ -1,6 +1,6 @@
 { pkgs ? import ./nixpkgs-pinned.nix {} }:
   pkgs.mkShell rec {
-    python = pkgs.python311.withPackages (ps: [
+    python = pkgs.python313.withPackages (ps: [
       ps.fastapi
       ps.google-cloud-storage
       ps.httpx

--- a/justfile
+++ b/justfile
@@ -57,7 +57,7 @@ test-integration *TEST_ARGS: build-bin build-python
 
 # Python integration test suite, using artefacts built through Nix. Args are forwarded to pytest
 [group('nix')]
-nix-test-integration *TEST_ARGS: nix-build-bin
+nix-test-integration *TEST_ARGS: nix-build
   #!/usr/bin/env bash
   set -euo pipefail
   nix_build_python_library_dir=$(just nix-build-python)

--- a/libs/opsqueue_python/examples/tracing/tracing_producer.py
+++ b/libs/opsqueue_python/examples/tracing/tracing_producer.py
@@ -1,12 +1,12 @@
 import logging
 import typing
-import opentelemetry
 import opentelemetry.context
 from opentelemetry.context import Context
 
 import contextlib
 from typing import Optional, Generator
 from opentelemetry import trace
+from opentelemetry import baggage as otel_baggage
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import (
     BatchSpanProcessor,
@@ -66,7 +66,7 @@ def added_baggage(
 
     if baggage:
         for key, value in baggage.items():
-            attached_token = opentelemetry.baggage.set_baggage(key, value, context)
+            attached_token = otel_baggage.set_baggage(key, value, context)
             attached_context_tokens.append(
                 typing.cast(Context, opentelemetry.context.attach(attached_token))
             )

--- a/libs/opsqueue_python/pyproject.toml
+++ b/libs/opsqueue_python/pyproject.toml
@@ -10,7 +10,7 @@ license="MIT"
 keywords=["queue", "processing", "paralellism", "distributed", "batch", "producer", "consumer"]
 
 
-requires-python = ">=3.8"
+requires-python = ">=3.13"
 classifiers = [
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",

--- a/nix/overlay.nix
+++ b/nix/overlay.nix
@@ -22,5 +22,4 @@ in
   python = python3;
 
   opsqueue = final.callPackage ../opsqueue/opsqueue.nix { };
-
 }

--- a/nix/sources.json
+++ b/nix/sources.json
@@ -17,10 +17,10 @@
         "homepage": "",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "6308c3b21396534d8aaeac46179c14c439a89b8a",
-        "sha256": "14qnx22pkl9v4r0lxnnz18f4ybxj8cv18hyf1klzap98hckg58y4",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "sha256": "1vq77hlx8mi3z03pw2nf6r5h7473r1p9yxyf58ym3fh01zppmfln",
         "type": "tarball",
-        "url": "https://github.com/NixOS/nixpkgs/archive/6308c3b21396534d8aaeac46179c14c439a89b8a.tar.gz",
+        "url": "https://github.com/NixOS/nixpkgs/archive/567a49d1913ce81ac6e9582e3553dd90a955875f.tar.gz",
         "url_template": "https://github.com/<owner>/<repo>/archive/<rev>.tar.gz"
     },
     "rust-overlay": {

--- a/nix/util.nix
+++ b/nix/util.nix
@@ -1,6 +1,5 @@
 # Utility functions to use in nix code
-{ lib }:
-{
+{ lib }: {
   # A powerful way of filtering the right files for the src attribute of a derivation.
   fileFilter =
     {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,5 @@
+[tool.mypy]
+strict = true
+follow_imports = "normal"
+show_error_codes = true
+warn_unused_configs = true

--- a/ruff.toml
+++ b/ruff.toml
@@ -1,0 +1,9 @@
+line-length = 88
+target-version = "py313"
+
+[format]
+quote-style = "double"
+indent-style = "space"
+line-ending = "lf"
+docstring-code-format = true
+docstring-code-line-length = "dynamic"


### PR DESCRIPTION
This prevents ruff from depending on the `./pyproject.toml` of a folder containing the Opsqueue checkout.