### PR TITLE
Add: cargo-semver-checks

### DIFF
--- a/.github/actions/setup-nix-direnv-rust/action.yml
+++ b/.github/actions/setup-nix-direnv-rust/action.yml
@@ -3,14 +3,14 @@ description: Checks out the git repo and sets up Nix, Direnv and Rust, with appr
 runs:
   using: "composite"
   steps:
-    - uses: nixbuild/nix-quick-install-action@8505cd40ae3d4791ca658f2697c5767212e5ce71  # v30
-    - uses: nix-community/cache-nix-action@135667ec418502fa5a3598af6fb9eb733888ce6a  # v6
+    - uses: nixbuild/nix-quick-install-action@9f63be77f412a248c9d9a65a4c82cf066cdf8f0c  # Latest as of 2026-07-31
+    - uses: nix-community/cache-nix-action@7df957e333c1e5da7721f60227dbba6d06080569  # Latest as of 2026-07-31
       with:
           # restore and save a cache using this key
           primary-key: nix-${{ runner.os }}-${{ hashFiles('**/*.nix', 'nix/sources.json', 'rust-toolchain.toml') }}
           # if there's no cache hit, restore a cache by this prefix
           restore-prefixes-first-match: nix-${{ runner.os }}-
-    - uses: HatsuneMiku3939/direnv-action@89ed6f6786c25aa7a69cd12f9fd0fdcb46c7c489  # Latest as of 2025-05-16
-    - uses: Swatinem/rust-cache@9d47c6ad4b02e050fd481d890b2ea34778fd09d6  # v2.7.8
+    - uses: HatsuneMiku3939/direnv-action@c81e6f10d47895cdd46432d8801bff0fabc73a6b  # Latest as of 2026-07-31
+    - uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4  # Latest as of 2026-07-31
       with:
         cache-all-crates: "true"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,4 @@ jobs:
       - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
       - uses: ./.github/actions/setup-nix-direnv-rust
       - run: |
-          just lint-light --show-diff-on-failure --all
-          just lint-heavy
+          just lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,27 @@
 name: Continuous Integration
-on: [push]
+"on": [push]
 jobs:
   test-unit:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # Latest as of 2026-07-31
       - uses: ./.github/actions/setup-nix-direnv-rust
       - run: just test-unit
   test-integration:
     name: Integration test (& build all in dev-mode)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # Latest as of 2026-07-31
       - uses: ./.github/actions/setup-nix-direnv-rust
       - run: OPSQUEUE_PYTEST_TIMEOUT=600 just test-integration
   lint:
     name: Lint & Style Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # Latest as of 2026-07-31
+        with:
+          fetch-tags: "true"
       - uses: ./.github/actions/setup-nix-direnv-rust
       - run: |
           just lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,25 +1,28 @@
 name: Continuous Integration
-on: [push]
+"on": [push]
 jobs:
   test-unit:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # Latest as of 2026-07-31
       - uses: ./.github/actions/setup-nix-direnv-rust
       - run: just test-unit
   test-integration:
     name: Integration test (& build all in dev-mode)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # Latest as of 2026-07-31
       - uses: ./.github/actions/setup-nix-direnv-rust
       - run: OPSQUEUE_PYTEST_TIMEOUT=600 just test-integration
   lint:
     name: Lint & Style Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # Latest as of 2026-07-31
+        with:
+          # We need tags for the `just semver` check, which is part of `just lint`, so we fetch them here.
+          fetch-tags: "true"
       - uses: ./.github/actions/setup-nix-direnv-rust
       - run: |
           just lint

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -86,5 +86,4 @@ blocks:
       jobs:
         - name: "Type- and format-check"
           commands:
-            - "just lint-light --show-diff-on-failure --all"
-            - "just lint-heavy"
+            - "just lint"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "opsqueue"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2154,7 +2154,7 @@ dependencies = [
 
 [[package]]
 name = "opsqueue_python"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ hakari-package = "workspace-hack"
 
 [workspace.package]
 edition = "2024"
-version = "0.38.0"
+version = "0.39.0"
 
 [workspace.dependencies]
 anyhow = { version = "1.0.102" }

--- a/default.nix
+++ b/default.nix
@@ -47,9 +47,10 @@ let
       # Rust build tools
       pkgs.cargo-audit
       pkgs.cargo-edit
-      pkgs.cargo-insta
       pkgs.cargo-hakari
+      pkgs.cargo-insta
       pkgs.cargo-nextest
+      pkgs.cargo-semver-checks
       pkgs.maturin
 
       # Resolve native sqlite from Nix for libsqlite3-sys

--- a/justfile
+++ b/justfile
@@ -77,7 +77,7 @@ nix-test-integration *TEST_ARGS: nix-build
 
 # Run all linters, fast and slow
 [group('lint')]
-lint: (lint-light "--all-files") lint-heavy
+lint: (lint-light "--show-diff-on-failure" "--all-files") lint-heavy
 
 # Run only the fast per-file linters; these might opt to only look at the changed files. Args are passed to pre-commit
 [group('lint')]

--- a/justfile
+++ b/justfile
@@ -87,7 +87,7 @@ bench-chunks-select:
 
 # Run all linters, fast and slow
 [group('lint')]
-lint: (lint-light "--all-files") lint-heavy
+lint: (lint-light "--show-diff-on-failure" "--all-files") lint-heavy
 
 # Run only the fast per-file linters; these might opt to only look at the changed files. Args are passed to pre-commit
 [group('lint')]

--- a/justfile
+++ b/justfile
@@ -87,7 +87,23 @@ lint-light *ARGS:
 # Run the slow linters/static analysers that need to look at everything
 [group('lint')]
 [parallel]
-lint-heavy: clippy-fix lint-cargo mypy
+lint-heavy: semver clippy-fix lint-cargo mypy
+
+# Verify the semver bounds are respected since the last tagged build
+[group('lint')]
+semver:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  export DATABASE_URL="sqlite://{{justfile_directory()}}/opsqueue/opsqueue_example_database_schema.db"
+  cargo semver-checks --workspace --target x86_64-unknown-linux-gnu --baseline-rev "$(git tag -l --sort=-version:refname | head -1)"
+
+# Rust static analysis
+[group('lint')]
+clippy-fix:
+  # `cargo clippy --fix` caps lints to warnings internally; keep its artifacts separate.
+  CARGO_TARGET_DIR=target/clippy-fix cargo clippy --no-deps --all-targets --fix --allow-dirty --allow-staged -- -Dwarnings
+  CARGO_TARGET_DIR=target/clippy-fix cargo clippy --no-deps --all-targets --no-default-features --fix --allow-dirty --allow-staged -- -Dwarnings
+  CARGO_TARGET_DIR=target/clippy-fix cargo clippy --no-deps --all-targets --all-features --fix --allow-dirty --allow-staged -- -Dwarnings
 
 # Serial execution on the main `CARGO_TARGET_DIR`
 [group('lint')]
@@ -97,14 +113,6 @@ lint-cargo: clippy hakari
 [group('lint')]
 hakari:
   cargo hakari verify
-
-# Rust static analysis
-[group('lint')]
-clippy-fix:
-  # `cargo clippy --fix` caps lints to warnings internally; keep its artifacts separate.
-  CARGO_TARGET_DIR=target/clippy-fix cargo clippy --no-deps --all-targets --fix --allow-dirty --allow-staged -- -Dwarnings
-  CARGO_TARGET_DIR=target/clippy-fix cargo clippy --no-deps --all-targets --no-default-features --fix --allow-dirty --allow-staged -- -Dwarnings
-  CARGO_TARGET_DIR=target/clippy-fix cargo clippy --no-deps --all-targets --all-features --fix --allow-dirty --allow-staged -- -Dwarnings
 
 # Rust static analysis
 [group('lint')]

--- a/justfile
+++ b/justfile
@@ -97,7 +97,24 @@ lint-light *ARGS:
 # Run the slow linters/static analysers that need to look at everything
 [group('lint')]
 [parallel]
-lint-heavy: clippy-fix lint-cargo mypy
+lint-heavy: semver clippy-fix lint-cargo mypy
+
+# Verify the semver bounds are respected since the last tagged build
+[group('lint')]
+semver:
+  #!/usr/bin/env bash
+  set -euo pipefail
+  export DATABASE_URL="sqlite://{{justfile_directory()}}/opsqueue/opsqueue_example_database_schema.db"
+  # We select the latest git tag, not to be confused with the latest Cargo version.
+  cargo semver-checks --workspace --target x86_64-unknown-linux-gnu --baseline-rev "$(git tag -l --sort=-version:refname | head -1)"
+
+# Rust static analysis
+[group('lint')]
+clippy-fix:
+  # `cargo clippy --fix` caps lints to warnings internally; keep its artifacts separate.
+  CARGO_TARGET_DIR=target/clippy-fix cargo clippy --no-deps --all-targets --fix --allow-dirty --allow-staged -- -Dwarnings
+  CARGO_TARGET_DIR=target/clippy-fix cargo clippy --no-deps --all-targets --no-default-features --fix --allow-dirty --allow-staged -- -Dwarnings
+  CARGO_TARGET_DIR=target/clippy-fix cargo clippy --no-deps --all-targets --all-features --fix --allow-dirty --allow-staged -- -Dwarnings
 
 # Serial execution on the main `CARGO_TARGET_DIR`
 [group('lint')]
@@ -107,14 +124,6 @@ lint-cargo: clippy hakari
 [group('lint')]
 hakari:
   cargo hakari verify
-
-# Rust static analysis
-[group('lint')]
-clippy-fix:
-  # `cargo clippy --fix` caps lints to warnings internally; keep its artifacts separate.
-  CARGO_TARGET_DIR=target/clippy-fix cargo clippy --no-deps --all-targets --fix --allow-dirty --allow-staged -- -Dwarnings
-  CARGO_TARGET_DIR=target/clippy-fix cargo clippy --no-deps --all-targets --no-default-features --fix --allow-dirty --allow-staged -- -Dwarnings
-  CARGO_TARGET_DIR=target/clippy-fix cargo clippy --no-deps --all-targets --all-features --fix --allow-dirty --allow-staged -- -Dwarnings
 
 # Rust static analysis
 [group('lint')]


### PR DESCRIPTION
This should prevent us from making semver incompatible changes without a required version bump.