### PR TITLE
reqwest-client -> reqwest-blocking-client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,7 +1995,7 @@ dependencies = [
 
 [[package]]
 name = "opsqueue"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "anyhow",
  "arc-swap",
@@ -2048,7 +2048,7 @@ dependencies = [
 
 [[package]]
 name = "opsqueue_python"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ hakari-package = "workspace-hack"
 
 [workspace.package]
 edition = "2024"
-version = "0.40.0"
+version = "0.40.1"
 
 [workspace.dependencies]
 anyhow = { version = "1.0.102", default-features = false }
@@ -42,7 +42,7 @@ object_store = { version = "0.14.0", default-features = false, features = ["gcp"
 once_cell = { version = "1.21.4", default-features = false }
 opentelemetry = { version = "0.32", default-features = false, features = ["trace"] }
 opentelemetry-http = { version = "0.32", default-features = false }
-opentelemetry-otlp = { version = "0.32", default-features = false, features = ["grpc-tonic", "trace", "http-proto", "reqwest-client"] }
+opentelemetry-otlp = { version = "0.32", default-features = false, features = ["grpc-tonic", "trace", "http-proto", "reqwest-blocking-client"] }
 opentelemetry-resource-detectors = { version = "0.11.0", default-features = false }
 opentelemetry-semantic-conventions = { version = "0.32.0", default-features = false, features = ["semconv_experimental"] }
 opentelemetry_sdk = { version = "0.32", default-features = false, features = ["trace", "rt-tokio"] }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -31,7 +31,7 @@ libsqlite3-sys = { version = "0.30", default-features = false, features = ["bund
 log = { version = "0.4", default-features = false, features = ["std"] }
 num-traits = { version = "0.2", default-features = false, features = ["std"] }
 opentelemetry = { version = "0.32" }
-opentelemetry-http = { version = "0.32", default-features = false, features = ["reqwest"] }
+opentelemetry-http = { version = "0.32", default-features = false, features = ["reqwest-blocking"] }
 opentelemetry_sdk = { version = "0.32", default-features = false, features = ["metrics", "rt-tokio", "trace"] }
 rand-274715c4dabd11b0 = { package = "rand", version = "0.9" }
 rand-93f6ce9d446188ac = { package = "rand", version = "0.10" }


### PR DESCRIPTION
Tested by copilot:

```
Diagnosis confirmed by reproduction. I built with reqwest-client (current master) and ran the server with OTEL_EXPORTER_OTLP_ENDPOINT
set:

 thread 'OpenTelemetry.Traces.BatchProcessor' (152196) panicked at .../core/src/ops/function.rs:250:5:
 there is no reactor running, must be called from the context of a Tokio 1.x runtime

Note the thread name: OpenTelemetry.Traces.BatchProcessor — the dedicated std::thread with no Tokio runtime, exactly as predicted.

Your change fixes it. Same binary, same env, with reqwest-blocking-client: runs to the timeout with zero panics. Verified via cargo tree
that opentelemetry-otlp now resolves reqwest-blocking-client and no longer reqwest-client
```